### PR TITLE
✨  [FEAT] 화면 공유 기능 및 매칭/채팅 기능 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ const SignupPage = lazy(() => import("./pages/SignupPage"));
 const ProfileSetupPage = lazy(() => import("./pages/ProfileSetupPage"));
 const MatchingPage = lazy(() => import("./pages/MatchingPage"));
 const WaitingRoomPage = lazy(() => import("./pages/WaitingRoomPage"));
+const ScreenShareSetupPage = lazy(() => import("./pages/ScreenShareSetupPage"));
 const BattlePage = lazy(() => import("./pages/BattlePage"));
 const ResultPage = lazy(() => import("./pages/ResultPage"));
 const TierPromotionPage = lazy(() => import("./pages/TierPromotionPage"));
@@ -75,6 +76,7 @@ const App = () => {
                 <Route path="/setup-profile" element={<ProfileSetupPage />} />
                 <Route path="/matching" element={<MatchingPage />} />
                 <Route path="/waiting-room" element={<WaitingRoomPage />} />
+                <Route path="/screen-share-setup" element={<ScreenShareSetupPage />} />
                 <Route path="/battle" element={<BattlePage />} />
                 <Route path="/result" element={<ResultPage />} />
                 <Route path="/tier-promotion" element={<TierPromotionPage />} />

--- a/src/pages/BattlePage.tsx
+++ b/src/pages/BattlePage.tsx
@@ -4,6 +4,7 @@ import { useUser } from '@/context/UserContext';
 import CyberCard from '@/components/CyberCard';
 import CyberButton from '@/components/CyberButton';
 import { Clock, Play, Send, Monitor, Flag, AlertTriangle, HelpCircle } from 'lucide-react';
+import { localStream as sharedLocalStream, remoteStream as sharedRemoteStream } from '@/utils/webrtcStore';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
@@ -13,6 +14,8 @@ const BattlePage = () => {
   const [searchParams] = useSearchParams();
   const gameId = searchParams.get('gameId');
   const wsRef = useRef<WebSocket | null>(null);
+  const localVideoRef = useRef<HTMLVideoElement | null>(null);
+  const remoteVideoRef = useRef<HTMLVideoElement | null>(null);
   const [timeLeft, setTimeLeft] = useState(930);
   const [code, setCode] = useState('');
   const [chatMessages, setChatMessages] = useState<{ user: string; message: string }[]>([]);
@@ -37,6 +40,16 @@ const BattlePage = () => {
     },
     hint: ['수학', '약수', '반복문', '완전탐색']
   };
+
+
+  useEffect(() => {
+    if (localVideoRef.current && sharedLocalStream) {
+      localVideoRef.current.srcObject = sharedLocalStream;
+    }
+    if (remoteVideoRef.current && sharedRemoteStream) {
+      remoteVideoRef.current.srcObject = sharedRemoteStream;
+    }
+  }, []);
 
    // 웹소켓 연결
    useEffect(() => {
@@ -277,11 +290,15 @@ const BattlePage = () => {
 
                 {/* 화면공유 */}
                 <CyberCard className="p-3 flex flex-col items-center justify-center">
-                  <Monitor className="h-8 w-8 text-gray-400 mb-2" />
-                  <div className="text-xs text-gray-400 text-center">
-                    <div>상대방 화면</div>
-                    <div className="mt-1 text-yellow-400">공유 대기중...</div>
-                  </div>
+                {sharedRemoteStream ? (
+                    <video ref={remoteVideoRef} autoPlay playsInline className="w-full h-full object-contain" />
+                  ) : (
+                    <div className="text-xs text-gray-400 text-center">
+                      <Monitor className="h-8 w-8 text-gray-400 mb-2" />
+                      <div>상대방 화면</div>
+                      <div className="mt-1 text-yellow-400">공유 대기중...</div>
+                    </div>
+                  )}
                 </CyberCard>
               </div>
             </div>

--- a/src/pages/BattlePage.tsx
+++ b/src/pages/BattlePage.tsx
@@ -4,7 +4,7 @@ import { useUser } from '@/context/UserContext';
 import CyberCard from '@/components/CyberCard';
 import CyberButton from '@/components/CyberButton';
 import { Clock, Play, Send, Monitor, Flag, AlertTriangle, HelpCircle } from 'lucide-react';
-import { localStream as sharedLocalStream, remoteStream as sharedRemoteStream } from '@/utils/webrtcStore';
+import { localStream as sharedLocalStream, remoteStream as sharedRemoteStream, setLocalStream, peerConnection as sharedPC } from '@/utils/webrtcStore';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
@@ -22,6 +22,8 @@ const BattlePage = () => {
   const [newMessage, setNewMessage] = useState('');
   const [executionResult, setExecutionResult] = useState('실행 결과가 여기에 표시됩니다.');
   const [showHint, setShowHint] = useState(false);
+  const [isLocalStreamActive, setIsLocalStreamActive] = useState(true);
+  const chatEndRef = useRef<HTMLDivElement | null>(null);
   
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const lineNumbersRef = useRef<HTMLDivElement>(null);
@@ -49,6 +51,15 @@ const BattlePage = () => {
     if (remoteVideoRef.current && sharedRemoteStream) {
       remoteVideoRef.current.srcObject = sharedRemoteStream;
     }
+
+    if (sharedLocalStream) {
+      const videoTrack = sharedLocalStream.getVideoTracks()[0];
+      if (videoTrack) {
+        videoTrack.onended = () => {
+          setIsLocalStreamActive(false);
+        };
+      }
+    }
   }, []);
 
    // 웹소켓 연결
@@ -63,11 +74,11 @@ const BattlePage = () => {
     ws.onmessage = (event) => {
       try {
         const data = JSON.parse(event.data);
-        if (data.type === 'chat') {
+        if (data.type === 'chat' && data.sender !== user.user_id) {
           setChatMessages((prev) => [
             ...prev,
             {
-              user: data.sender === user.user_id ? '나' : `상대`,
+              user: '상대',
               message: data.message,
             },
           ]);
@@ -81,6 +92,14 @@ const BattlePage = () => {
       ws.close();
     };
   }, [gameId, user]);
+
+  const scrollToBottom = () => {
+    chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [chatMessages]);
 
 
   useEffect(() => {
@@ -111,8 +130,8 @@ const BattlePage = () => {
 
     if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
       wsRef.current.send(JSON.stringify(msgObj));
+      setChatMessages((prev) => [...prev, { user: '나', message: newMessage }]);
     }
-
     
     setNewMessage('');
   };
@@ -125,6 +144,38 @@ const BattlePage = () => {
 
   const handleReport = () => {
     alert('신고가 접수되었습니다.');
+  };
+
+  const handleRestartScreenShare = async () => {
+    try {
+      const mediaStream = await navigator.mediaDevices.getDisplayMedia({
+        video: true,
+        audio: false,
+      });
+
+      if (localVideoRef.current) {
+        localVideoRef.current.srcObject = mediaStream;
+      }
+
+      setLocalStream(mediaStream);
+
+      if (sharedPC) {
+        const videoTrack = mediaStream.getVideoTracks()[0];
+        const sender = sharedPC.getSenders().find((s) => s.track?.kind === 'video');
+        if (sender) {
+          sender.replaceTrack(videoTrack);
+        }
+      }
+
+      const videoTrack = mediaStream.getVideoTracks()[0];
+      videoTrack.onended = () => {
+        setIsLocalStreamActive(false);
+      };
+
+      setIsLocalStreamActive(true);
+    } catch (error) {
+      console.error('Error restarting screen share:', error);
+    }
   };
 
   const timeColor = timeLeft <= 60 ? 'text-red-400' : timeLeft <= 180 ? 'text-yellow-400' : 'text-cyber-blue';
@@ -257,49 +308,54 @@ const BattlePage = () => {
               </div>
 
               {/* 좌측 하단 - 채팅 & 화면공유 (고정 높이) */}
-              <div className="h-48 grid grid-cols-2 gap-2 mr-2">
+              <div className="h-48 flex gap-2 mr-2">
                 {/* 채팅 */}
-                <CyberCard className="p-3 flex flex-col">
-                  <h3 className="text-sm font-semibold text-cyber-blue mb-2">채팅</h3>
-                  <ScrollArea className="flex-1 mb-2">
-                    <div className="space-y-2 pr-3">
-                      {chatMessages.map((msg, index) => (
-                        <div key={index} className="text-xs">
-                          <div className="text-gray-400">{msg.user}: {msg.message}</div>
-                        </div>
-                      ))}
+                <div className="flex-1 min-w-0">
+                  <CyberCard className="p-3 flex flex-col h-full">
+                    <h3 className="text-sm font-semibold text-cyber-blue mb-2">채팅</h3>
+                    <ScrollArea className="flex-1 mb-2">
+                      <div className="space-y-2 pr-3">
+                        {chatMessages.map((msg, index) => (
+                          <div key={index} className="text-xs">
+                            <div className="text-gray-400">{msg.user}: {msg.message}</div>
+                          </div>
+                        ))}
+                        <div ref={chatEndRef} />
+                      </div>
+                    </ScrollArea>
+                    <div className="flex">
+                      <input
+                        type="text"
+                        value={newMessage}
+                        onChange={(e) => setNewMessage(e.target.value)}
+                        onKeyPress={(e) => e.key === 'Enter' && handleSendMessage()}
+                        placeholder="메시지 입력..."
+                        className="flex-1 text-xs bg-black/30 border border-gray-600 rounded-l px-2 py-1 text-white"
+                      />
+                      <button
+                        onClick={handleSendMessage}
+                        className="bg-cyber-blue px-2 py-1 rounded-r"
+                      >
+                        <Send className="h-3 w-3" />
+                      </button>
                     </div>
-                  </ScrollArea>
-                  <div className="flex">
-                    <input
-                      type="text"
-                      value={newMessage}
-                      onChange={(e) => setNewMessage(e.target.value)}
-                      onKeyPress={(e) => e.key === 'Enter' && handleSendMessage()}
-                      placeholder="메시지 입력..."
-                      className="flex-1 text-xs bg-black/30 border border-gray-600 rounded-l px-2 py-1 text-white"
-                    />
-                    <button
-                      onClick={handleSendMessage}
-                      className="bg-cyber-blue px-2 py-1 rounded-r"
-                    >
-                      <Send className="h-3 w-3" />
-                    </button>
-                  </div>
-                </CyberCard>
+                  </CyberCard>
+                </div>
 
                 {/* 화면공유 */}
-                <CyberCard className="p-3 flex flex-col items-center justify-center">
-                {sharedRemoteStream ? (
-                    <video ref={remoteVideoRef} autoPlay playsInline className="w-full h-full object-contain" />
-                  ) : (
-                    <div className="text-xs text-gray-400 text-center">
-                      <Monitor className="h-8 w-8 text-gray-400 mb-2" />
-                      <div>상대방 화면</div>
-                      <div className="mt-1 text-yellow-400">공유 대기중...</div>
-                    </div>
-                  )}
-                </CyberCard>
+                <div className="flex-1 min-w-0">
+                  <CyberCard className="p-3 flex flex-col items-center justify-center h-full">
+                  {sharedRemoteStream ? (
+                      <video ref={remoteVideoRef} autoPlay playsInline className="w-full h-full object-contain" />
+                    ) : (
+                      <div className="text-xs text-gray-400 text-center">
+                        <Monitor className="h-8 w-8 text-gray-400 mb-2" />
+                        <div>상대방 화면</div>
+                        <div className="mt-1 text-yellow-400">공유 대기중...</div>
+                      </div>
+                    )}
+                  </CyberCard>
+                </div>
               </div>
             </div>
           </ResizablePanel>

--- a/src/pages/MatchingPage.tsx
+++ b/src/pages/MatchingPage.tsx
@@ -51,10 +51,7 @@ const MatchingPage = () => {
         // You might want to update opponent details here based on message.opponent_ids
       } else if (message.type === 'match_accepted') {
         setOpponentAccepted(true);
-        // 상대방도 수락하여 매칭이 성사됨
-        setTimeout(() => {
-          navigate(`/screen-share-setup?gameId=${message.game_id}`);
-        }, 1000);
+        navigate(`/screen-share-setup?gameId=${message.game_id}`);
       } else if (message.type === 'match_cancelled') {
         console.log('Match cancelled:', message.reason);
         setFoundOpponent(false);

--- a/src/pages/MatchingPage.tsx
+++ b/src/pages/MatchingPage.tsx
@@ -12,6 +12,8 @@ const MatchingPage = () => {
   const [matchingTime, setMatchingTime] = useState(0);
   const [foundOpponent, setFoundOpponent] = useState(false);
   const [acceptTimeLeft, setAcceptTimeLeft] = useState(20);
+  const [userAccepted, setUserAccepted] = useState(false);
+  const [opponentAccepted, setOpponentAccepted] = useState(false);
   const [opponent] = useState({
     name: 'CodeWarrior',
     mmr: 1823,
@@ -42,16 +44,24 @@ const MatchingPage = () => {
 
       if (message.type === 'match_found') {
         setFoundOpponent(true);
+        setUserAccepted(false);
+        setOpponentAccepted(false);
         setAcceptTimeLeft(message.time_limit);
         matchIdRef.current = message.match_id;
         // You might want to update opponent details here based on message.opponent_ids
       } else if (message.type === 'match_accepted') {
-        navigate(`/battle?gameId=${message.game_id}`);
+        setOpponentAccepted(true);
+        // 상대방도 수락하여 매칭이 성사됨
+        setTimeout(() => {
+          navigate(`/screen-share-setup?gameId=${message.game_id}`);
+        }, 1000);
       } else if (message.type === 'match_cancelled') {
         console.log('Match cancelled:', message.reason);
         setFoundOpponent(false);
         setMatchingTime(0);
         setAcceptTimeLeft(20);
+        setUserAccepted(false);
+        setOpponentAccepted(false);
         matchIdRef.current = null;
         if (message.reason === 'timeout or rejection') {
           navigate('/home'); // Go back to home or a suitable page
@@ -109,6 +119,7 @@ const MatchingPage = () => {
   const handleAccept = () => {
     console.log('handleAccept called');
     if (ws && matchIdRef.current) {
+      setUserAccepted(true);
       const message = { type: 'match_accept', match_id: matchIdRef.current };
       console.log('Sending WebSocket message:', message);
       ws.send(JSON.stringify(message));
@@ -118,6 +129,7 @@ const MatchingPage = () => {
   };
 
   const handleDecline = () => {
+    if (userAccepted) return; // 이미 수락한 경우 거절 불가
     if (ws && matchIdRef.current) {
       ws.send(JSON.stringify({ type: 'match_reject', match_id: matchIdRef.current }));
     }
@@ -231,16 +243,24 @@ const MatchingPage = () => {
                       <div className="text-center space-y-4">
                         <div className="text-2xl font-bold text-white">코딩 배틀</div>
                         <div className="text-sm text-gray-300">랭크 매칭</div>
-                        <div className="text-lg text-cyber-blue font-mono">
-                          {acceptTimeLeft}초
-                        </div>
+                        {!userAccepted || !opponentAccepted ? (
+                          <div className="text-lg text-cyber-blue font-mono">
+                            {acceptTimeLeft}초
+                          </div>
+                        ) : (
+                          <div className="text-lg text-green-400 font-mono">
+                            수락됨
+                          </div>
+                        )}
                       </div>
                     </div>
 
                     {/* 타이머 텍스트 */}
-                    <div className="absolute top-4 left-1/2 transform -translate-x-1/2 text-white font-bold text-lg">
-                      {acceptTimeLeft}
-                    </div>
+                    {(!userAccepted || !opponentAccepted) && (
+                      <div className="absolute top-4 left-1/2 transform -translate-x-1/2 text-white font-bold text-lg">
+                        {acceptTimeLeft}
+                      </div>
+                    )}
                   </div>
 
                   {/* 상대방 정보 (간소화) */}
@@ -252,6 +272,12 @@ const MatchingPage = () => {
                         </div>
                         <div className="text-sm text-white">CyberCoder</div>
                         <div className="text-xs text-cyber-blue">Gold III</div>
+                        {userAccepted && (
+                          <div className="text-xs text-green-400 mt-1 flex items-center justify-center">
+                            <Check className="h-3 w-3 mr-1" />
+                            수락함
+                          </div>
+                        )}
                       </div>
                       
                       <div className="text-2xl font-bold neon-text">VS</div>
@@ -262,30 +288,61 @@ const MatchingPage = () => {
                         </div>
                         <div className="text-sm text-white">{opponent.name}</div>
                         <div className="text-xs text-red-400">{opponent.rank}</div>
+                        {opponentAccepted && (
+                          <div className="text-xs text-green-400 mt-1 flex items-center justify-center">
+                            <Check className="h-3 w-3 mr-1" />
+                            수락함
+                          </div>
+                        )}
                       </div>
                     </div>
                   </div>
 
-                  {/* 수락/거절 버튼 */}
-                  <div className="flex justify-center gap-8">
-                    <CyberButton 
-                      onClick={handleAccept}
-                      size="lg"
-                      className="w-32 h-16 text-lg bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-400 hover:to-emerald-500"
-                    >
-                      <Check className="h-6 w-6" />
-                      수락
-                    </CyberButton>
-                    <CyberButton 
-                      onClick={handleDecline}
-                      variant="danger"
-                      size="lg"
-                      className="w-32 h-16 text-lg"
-                    >
-                      <X className="h-6 w-6" />
-                      거절
-                    </CyberButton>
-                  </div>
+                  {/* 수락/거절 버튼 또는 상태 */}
+                  {!userAccepted && !opponentAccepted && (
+                    <div className="flex justify-center gap-8">
+                      <CyberButton
+                        onClick={handleAccept}
+                        size="lg"
+                        className="w-32 h-16 text-lg bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-400 hover:to-emerald-500"
+                      >
+                        <Check className="h-6 w-6" />
+                        수락
+                      </CyberButton>
+                      <CyberButton
+                        onClick={handleDecline}
+                        variant="danger"
+                        size="lg"
+                        className="w-32 h-16 text-lg"
+                      >
+                        <X className="h-6 w-6" />
+                        거절
+                      </CyberButton>
+                    </div>
+                  )}
+
+                  {userAccepted && !opponentAccepted && (
+                    <div className="text-center space-y-4">
+                      <div className="text-green-400 font-semibold text-lg flex items-center justify-center">
+                        <Check className="h-5 w-5 mr-2" />
+                        수락 완료! 상대방을 기다리는 중...
+                      </div>
+                      <div className="animate-pulse text-cyber-blue">
+                        상대방이 수락하길 기다리고 있습니다
+                      </div>
+                    </div>
+                  )}
+
+                  {userAccepted && opponentAccepted && (
+                    <div className="text-center space-y-4">
+                      <div className="text-green-400 font-bold text-xl">
+                        매칭 성공!
+                      </div>
+                      <div className="text-cyber-blue">
+                        게임을 시작합니다...
+                      </div>
+                    </div>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/pages/MatchingPage.tsx
+++ b/src/pages/MatchingPage.tsx
@@ -52,6 +52,8 @@ const MatchingPage = () => {
       } else if (message.type === 'match_accepted') {
         setOpponentAccepted(true);
         navigate(`/screen-share-setup?gameId=${message.game_id}`);
+      } else if (message.type === 'opponent_accepted') {
+        setOpponentAccepted(true);
       } else if (message.type === 'match_cancelled') {
         console.log('Match cancelled:', message.reason);
         setFoundOpponent(false);
@@ -296,7 +298,7 @@ const MatchingPage = () => {
                   </div>
 
                   {/* 수락/거절 버튼 또는 상태 */}
-                  {!userAccepted && !opponentAccepted && (
+                  {!userAccepted && (
                     <div className="flex justify-center gap-8">
                       <CyberButton
                         onClick={handleAccept}

--- a/src/pages/ScreenShareSetupPage.tsx
+++ b/src/pages/ScreenShareSetupPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import CyberCard from '@/components/CyberCard';
 import CyberButton from '@/components/CyberButton';
-import { Monitor, User, Clock, AlertTriangle, Check, Video } from 'lucide-react';
+import { Monitor, User, Clock, AlertTriangle, Check } from 'lucide-react';
 import { useUser } from '@/context/UserContext';
 import { localStream as sharedLocalStream, remoteStream as sharedRemoteStream, 
     setLocalStream, setRemoteStream, setPeerConnection, peerConnection as sharedPC } from '@/utils/webrtcStore';
@@ -16,6 +16,7 @@ const ScreenShareSetupPage = () => {
   const localVideoRef = useRef<HTMLVideoElement | null>(null);
   const remoteVideoRef = useRef<HTMLVideoElement | null>(null);
   const [myStream, setMyStream] = useState<MediaStream | null>(null);
+  const [remoteStreamState, setRemoteStreamState] = useState<MediaStream | null>(null);
   const [myShareStatus, setMyShareStatus] = useState<'waiting' | 'sharing' | 'invalid' | 'valid'>('waiting');
   const [opponentReady, setOpponentReady] = useState(false);
   const [myReady, setMyReady] = useState(false);
@@ -123,6 +124,13 @@ const ScreenShareSetupPage = () => {
   }, [myStream]);
 
   useEffect(() => {
+    if (remoteStreamState && remoteVideoRef.current) {
+      remoteVideoRef.current.srcObject = remoteStreamState;
+    }
+  }, [remoteStreamState]);
+
+
+  useEffect(() => {
     if (!gameId || !user?.user_id) return;
 
     const ws = new WebSocket(
@@ -182,6 +190,7 @@ const ScreenShareSetupPage = () => {
         console.log('Remote video track readyState:', track.readyState, 'enabled:', track.enabled);
       });
       setRemoteStream(stream);
+      setRemoteStreamState(stream);
       if (remoteVideoRef.current) {
         remoteVideoRef.current.srcObject = stream;
       }
@@ -367,7 +376,7 @@ const ScreenShareSetupPage = () => {
               </h3>
 
               <div className="aspect-video bg-black/50 rounded-lg border-2 border-cyber-blue/30 flex items-center justify-center mb-4">
-                {opponentReady ? (
+                {remoteStreamState ? (
                   <video ref={remoteVideoRef} autoPlay playsInline muted className="w-full h-full object-contain" />
                 ) : (
                   <div className="text-center">

--- a/src/pages/ScreenShareSetupPage.tsx
+++ b/src/pages/ScreenShareSetupPage.tsx
@@ -39,6 +39,15 @@ const ScreenShareSetupPage = () => {
         setMyShareStatus('valid');
         setMyStream(mediaStream);
         setLocalStream(mediaStream);
+        // 이미 연결이 존재하면 트랙을 추가하고 재협상
+        if (sharedPC) {
+            mediaStream.getTracks().forEach((track) => sharedPC.addTrack(track, mediaStream));
+            const offer = await sharedPC.createOffer();
+            await sharedPC.setLocalDescription(offer);
+            wsRef.current?.send(
+              JSON.stringify({ type: 'webrtc_signal', signal: sharedPC.localDescription })
+            );
+          }
         // 화면 공유가 종료되었을 때 감지
         videoTrack.addEventListener('ended', () => {
             console.log('Screen share ended');
@@ -48,7 +57,7 @@ const ScreenShareSetupPage = () => {
             setMyReady(false);
             setIsCountingDown(false);
             setCountdown(0);
-          });
+        });
       } else {
         setMyShareStatus('invalid');
         setMyReady(false);

--- a/src/pages/ScreenShareSetupPage.tsx
+++ b/src/pages/ScreenShareSetupPage.tsx
@@ -1,0 +1,296 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import CyberCard from '@/components/CyberCard';
+import CyberButton from '@/components/CyberButton';
+import { Monitor, User, Clock, AlertTriangle, Check, Video } from 'lucide-react';
+
+const ScreenShareSetupPage = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const gameId = searchParams.get('gameId');
+  const [myStream, setMyStream] = useState<MediaStream | null>(null);
+  const [myShareStatus, setMyShareStatus] = useState<'waiting' | 'sharing' | 'invalid' | 'valid'>('waiting');
+  const [opponentReady, setOpponentReady] = useState(false);
+  const [myReady, setMyReady] = useState(false);
+  const [countdown, setCountdown] = useState(0);
+  const [isCountingDown, setIsCountingDown] = useState(false);
+
+  const startScreenShare = async () => {
+    try {
+      setMyShareStatus('sharing');
+      const mediaStream = await navigator.mediaDevices.getDisplayMedia({
+        video: true,
+        audio: false
+      });
+
+      const videoTrack = mediaStream.getVideoTracks()[0];
+      const settings = videoTrack.getSettings() as any;
+
+      console.log('Screen share settings:', settings);
+
+      if (settings.displaySurface === 'monitor') {
+        setMyShareStatus('valid');
+        setMyStream(mediaStream);
+        // 화면 공유가 종료되었을 때 감지
+        videoTrack.addEventListener('ended', () => {
+            console.log('Screen share ended');
+            setMyShareStatus('waiting');
+            setMyStream(null);
+            setMyReady(false);
+            setIsCountingDown(false);
+            setCountdown(0);
+          });
+      } else {
+        setMyShareStatus('invalid');
+        setMyReady(false);
+        setIsCountingDown(false);
+        setCountdown(0);
+        mediaStream.getTracks().forEach(track => track.stop());
+      }
+    } catch (error) {
+      console.error('Screen share failed:', error);
+      setMyShareStatus('waiting');
+    }
+  };
+
+  const handleRetryShare = () => {
+    setMyShareStatus('waiting');
+    startScreenShare();
+  };
+
+  const handleReady = () => {
+    if (myShareStatus === 'valid') {
+      setMyReady(true);
+      // 시뮬레이션: 상대방도 준비됨 (더미 데이터)
+      setTimeout(() => {
+        setOpponentReady(true);
+      }, 2000);
+    }
+  };
+
+  useEffect(() => {
+    if (myReady && !isCountingDown) {
+      console.log('Starting countdown...');
+      setIsCountingDown(true);
+      setCountdown(3);
+    }
+  }, [myReady, isCountingDown]);
+
+  useEffect(() => {
+    if (isCountingDown && countdown > 0) {
+      console.log('Countdown:', countdown);
+      const timer = setTimeout(() => {
+        setCountdown(prev => prev - 1);
+      }, 1000);
+
+      return () => clearTimeout(timer);
+    } else if (isCountingDown && countdown === 0) {
+      console.log('Game starting...');
+      if (myStream) {
+        myStream.getTracks().forEach(track => track.stop());
+      }
+      if (gameId) {
+        navigate(`/battle?gameId=${gameId}`);
+      } else {
+        navigate('/battle');
+      }
+    }
+  }, [isCountingDown, countdown, myStream, navigate, gameId]);
+
+  useEffect(() => {
+    startScreenShare();
+  }, []);
+
+  return (
+    <div className="min-h-screen cyber-grid bg-cyber-darker">
+      <header className="cyber-card border-b border-cyber-blue/20 backdrop-blur-md">
+        <div className="container mx-auto px-4 py-3">
+          <div className="flex items-center justify-center">
+            <span className="text-xl font-bold neon-text">화면 공유 설정</span>
+          </div>
+        </div>
+      </header>
+
+      {isCountingDown && countdown > 0 && (
+        <div className="fixed inset-0 bg-black/80 backdrop-blur-md z-50 flex items-center justify-center animate-fade-in">
+          <div className="text-center">
+            <div className="text-8xl font-bold neon-text mb-4 animate-bounce">
+              <span
+                key={countdown}
+                className="inline-block animate-pulse"
+                style={{
+                  animation: 'pulse 0.5s ease-in-out, bounce 0.6s ease-in-out',
+                  textShadow: '0 0 30px rgba(0, 200, 255, 0.8), 0 0 60px rgba(0, 200, 255, 0.6)'
+                }}
+              >
+                {countdown}
+              </span>
+            </div>
+            <div className="text-2xl text-cyber-blue animate-pulse">
+              게임이 곧 시작됩니다!
+            </div>
+            <div className="mt-6 w-48 h-2 bg-gray-700 rounded-full mx-auto overflow-hidden">
+              <div
+                className="h-full bg-gradient-to-r from-cyber-blue to-cyber-purple rounded-full transition-all duration-1000 ease-linear"
+                style={{
+                  width: `${((4 - countdown) / 3) * 100}%`,
+                  boxShadow: '0 0 10px rgba(0, 200, 255, 0.5)'
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      <main className="container mx-auto px-4 py-8">
+        <div className="max-w-6xl mx-auto">
+          <div className="mb-8">
+            <CyberCard className="p-6">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-4">
+                  <div className="w-12 h-12 bg-gradient-to-r from-cyber-blue to-cyber-purple rounded-full flex items-center justify-center">
+                    <User className="h-6 w-6 text-white" />
+                  </div>
+                  <div>
+                    <div className="text-white font-semibold">나</div>
+                    <div className="flex items-center space-x-2">
+                      {myShareStatus === 'valid' && (
+                        <Check className="h-4 w-4 text-green-400" />
+                      )}
+                      <span className={`text-sm ${
+                        myShareStatus === 'valid' ? 'text-green-400' :
+                        myShareStatus === 'invalid' ? 'text-red-400' :
+                        'text-yellow-400'
+                      }`}>
+                        {myShareStatus === 'valid' ? '화면 공유 완료' :
+                         myShareStatus === 'invalid' ? '전체 화면 필요' :
+                         myShareStatus === 'sharing' ? '공유 설정 중...' :
+                         '화면 공유 대기'}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="text-2xl font-bold neon-text">VS</div>
+
+                <div className="flex items-center space-x-4">
+                  <div>
+                    <div className="text-white font-semibold text-right">상대방</div>
+                    <div className="flex items-center justify-end space-x-2">
+                      {opponentReady && (
+                        <Check className="h-4 w-4 text-green-400" />
+                      )}
+                      <span className={`text-sm ${opponentReady ? 'text-green-400' : 'text-yellow-400'}`}>
+                        {opponentReady ? '준비 완료' : '준비 중...'}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="w-12 h-12 bg-gradient-to-r from-red-500 to-pink-500 rounded-full flex items-center justify-center">
+                    <User className="h-6 w-6 text-white" />
+                  </div>
+                </div>
+              </div>
+            </CyberCard>
+          </div>
+
+          <div className="grid grid-cols-2 gap-8 mb-8">
+            <CyberCard className="p-6">
+              <h3 className="text-lg font-semibold text-cyber-blue mb-4 flex items-center">
+                <Monitor className="mr-2 h-5 w-5" />
+                내 화면 공유
+              </h3>
+
+              <div className="aspect-video bg-black/50 rounded-lg border-2 border-cyber-blue/30 flex items-center justify-center mb-4">
+                {myShareStatus === 'valid' ? (
+                  <div className="text-center">
+                    <Video className="h-12 w-12 text-green-400 mx-auto mb-2" />
+                    <div className="text-green-400 font-semibold">화면 공유 중</div>
+                    <div className="text-sm text-gray-400">전체 화면이 공유되고 있습니다</div>
+                  </div>
+                ) : myShareStatus === 'invalid' ? (
+                  <div className="text-center">
+                    <AlertTriangle className="h-12 w-12 text-red-400 mx-auto mb-2" />
+                    <div className="text-red-400 font-semibold">전체 화면이 아님</div>
+                    <div className="text-sm text-gray-400">창이나 탭이 아닌 전체 화면을 선택해주세요</div>
+                  </div>
+                ) : myShareStatus === 'sharing' ? (
+                  <div className="text-center">
+                    <Clock className="h-12 w-12 text-yellow-400 mx-auto mb-2 animate-spin" />
+                    <div className="text-yellow-400 font-semibold">공유 설정 중...</div>
+                  </div>
+                ) : (
+                  <div className="text-center">
+                    <Monitor className="h-12 w-12 text-gray-400 mx-auto mb-2" />
+                    <div className="text-gray-400">화면 공유 대기 중</div>
+                  </div>
+                )}
+              </div>
+
+              <div className="flex justify-center space-x-3">
+                {(myShareStatus === 'invalid' || myShareStatus === 'waiting') && (
+                  <CyberButton onClick={handleRetryShare} size="sm">
+                    {myShareStatus === 'waiting' ? '화면 공유 시작' : '다시 시도'}
+                  </CyberButton>
+                )}
+                {myShareStatus === 'valid' && !myReady && (
+                  <CyberButton onClick={handleReady} className="bg-gradient-to-r from-green-500 to-emerald-600">
+                    준비 완료
+                  </CyberButton>
+                )}
+                {myReady && (
+                  <div className="flex items-center space-x-2 text-green-400">
+                    <Check className="h-5 w-5" />
+                    <span className="font-semibold">준비됨</span>
+                  </div>
+                )}
+              </div>
+            </CyberCard>
+
+            <CyberCard className="p-6">
+              <h3 className="text-lg font-semibold text-cyber-blue mb-4 flex items-center">
+                <Monitor className="mr-2 h-5 w-5" />
+                상대방 화면 공유
+              </h3>
+
+              <div className="aspect-video bg-black/50 rounded-lg border-2 border-cyber-blue/30 flex items-center justify-center mb-4">
+                {opponentReady ? (
+                  <div className="text-center">
+                    <Video className="h-12 w-12 text-green-400 mx-auto mb-2" />
+                    <div className="text-green-400 font-semibold">화면 공유 중</div>
+                    <div className="text-sm text-gray-400">상대방의 화면이 공유되고 있습니다</div>
+                  </div>
+                ) : (
+                  <div className="text-center">
+                    <Clock className="h-12 w-12 text-yellow-400 mx-auto mb-2 animate-pulse" />
+                    <div className="text-yellow-400 font-semibold">대기 중...</div>
+                    <div className="text-sm text-gray-400">상대방이 화면 공유를 설정하고 있습니다</div>
+                  </div>
+                )}
+              </div>
+            </CyberCard>
+          </div>
+
+          <CyberCard className="p-4">
+            <div className="text-center">
+              {!myReady ? (
+                <div className="text-gray-300">
+                  전체 화면을 공유하고 준비 버튼을 눌러주세요
+                </div>
+              ) : isCountingDown ? (
+                <div className="text-green-400 font-semibold">
+                  게임이 곧 시작됩니다!
+                </div>
+              ) : (
+                <div className="text-green-400 font-semibold">
+                  준비 완료! 게임 시작을 기다리고 있습니다.
+                </div>
+              )}
+            </div>
+          </CyberCard>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default ScreenShareSetupPage;

--- a/src/utils/webrtcStore.ts
+++ b/src/utils/webrtcStore.ts
@@ -1,0 +1,15 @@
+export let localStream: MediaStream | null = null;
+export let remoteStream: MediaStream | null = null;
+export let peerConnection: RTCPeerConnection | null = null;
+
+export const setLocalStream = (stream: MediaStream | null) => {
+  localStream = stream;
+};
+
+export const setRemoteStream = (stream: MediaStream | null) => {
+  remoteStream = stream;
+};
+
+export const setPeerConnection = (pc: RTCPeerConnection | null) => {
+  peerConnection = pc;
+};


### PR DESCRIPTION
## 요약
본 PR은 화면 공유 기능을 추가하고 매칭 페이지 및 전투 페이지의 채팅 기능을 개선합니다. 이를 통해 사용자 경험을 향상시키고, 매칭과 게임 플레이 중 상호작용을 강화합니다.

## 주요 변경 사항

### 1. 화면 공유 기능 추가 및 개선
- **화면 공유 설정 페이지 추가:** 게임 시작 전 화면을 공유할 수 있는 전용 설정 페이지를 추가했습니다.
- **비디오 스트림 처리:** 전투 페이지와 화면 공유 설정 페이지에서 로컬·원격 비디오 스트림을 처리하는 로직을 구현했습니다.
- **화면 공유 중단 감지 및 재시작:** 사용자의 화면 공유가 중단되면 이를 감지하고, 다시 화면 공유를 시작할 수 있는 버튼을 활성화했습니다.
- **상대방 화면 공유 중단 알림:** 상대방의 화면 공유가 중단되면 채팅창에 알림 메시지를 표시하도록 개선했습니다.

### 2. 매칭 및 채팅 기능 개선
- **매칭 페이지 상대방 수락 상태 처리:** 매칭 성사 후 상대방의 수락 여부를 실시간으로 확인할 수 있도록 매칭 페이지 로직을 개선했습니다.
- **채팅창 자동 스크롤:** 전투 페이지 채팅창에 새 메시지가 도착할 때마다 자동으로 최신 메시지를 보여주도록 구현했습니다.
- **채팅 메시지 표시 개선:** 내가 보낸 메시지는 즉시 표시되고, 상대방 메시지는 웹소켓 수신 시 표시되도록 처리 로직을 개선했습니다.

## 영향 범위
- `src/pages/BattlePage.tsx`
- `src/pages/MatchingPage.tsx`
- `src/pages/ScreenShareSetupPage.tsx`
- `src/utils/webrtcStore.ts`
- `src/components/CyberCard.tsx`
- `src/components/ui/resizable.tsx`

## 테스트 방법
1. 매칭 페이지에서 매칭을 시도해 상대방 수락 상태가 올바르게 표시되는지 확인합니다.
2. 매칭 수락 후 화면 공유 설정 페이지로 이동해 화면 공유가 정상적으로 시작되는지 확인합니다.
3. 전투 페이지에서 채팅을 입력해 새 메시지가 자동 스크롤되는지 확인합니다.
4. 화면 공유 중지 시 “내 화면 다시 공유” 버튼이 활성화되고, 상대방 화면 공유 중지 시 채팅창에 알림이 표시되는지 확인합니다.
