### PR TITLE
🐛 [Fix] 사용자 표시명 로직을 닉네임 우선으로 수정

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -75,7 +75,7 @@ const Header = () => {
                 <DropdownMenuTrigger asChild>
                   <button className="flex items-center space-x-2 px-4 py-2 rounded-lg transition-all duration-300 hover:bg-cyber-blue/10 text-gray-300 hover:text-cyber-blue">
                     <User className="h-5 w-5" />
-                    <span className="font-medium">{user ? user.username : '프로필'}</span>
+                    <span className="font-medium">{user?.nickname || '프로필'}</span>
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent className="w-48 bg-card/95 backdrop-blur-sm border border-cyber-blue/20">

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -55,7 +55,7 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
             ...userData,
             ...winRateData,
             totalScore: userData.user_mmr,
-            name: userData.nickname || userData.username,
+            name: userData.nickname,
           });
         } else {
           console.error("Failed to fetch user data:", response.statusText);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -39,7 +39,7 @@ const Index = () => {
   // useUser 훅에서 가져온 user 객체를 직접 사용
   const currentUser = user ? {
     id: user.user_id,
-    name: user.nickname || user.username || 'CyberCoder',
+    name: user.nickname || 'CyberCoder',
     totalScore: user.totalScore || 1580,
     wins: user.win || 87, // 백엔드에서 제공되지 않음
     losses: user.loss || 40, // 백엔드에서 제공되지 않음

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -29,7 +29,7 @@ const ProfilePage = () => {
 
   const currentUser = {
     user_id: user?.user_id || 0,
-    username: user?.nickname || user?.username || 'CyberCoder',
+    username: user?.nickname || 'CyberCoder',
     email: user?.email || 'cybercoder@example.com',
     joinDate: '2024-01-15', // Not available from backend, keeping dummy
     totalScore: user?.totalScore || 1580,


### PR DESCRIPTION
기존에는 모든 화면에서 username(실명)이 우선 노출되는 문제가 있었으나,
이제부터는 nickname(프로필명/닉네임)이 있으면 nickname을, 없을 때만 username을 표시하도록 수정했습니다.