### PR TITLE
🐛 [Fix] 코드 실행 시 match_id 포함 / ✨ [FEAT] 제출 시 확인 다이얼로그

### DIFF
--- a/src/components/SubmitConfirmModal.tsx
+++ b/src/components/SubmitConfirmModal.tsx
@@ -1,0 +1,37 @@
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
+import CyberButton from '@/components/CyberButton';
+
+interface SubmitConfirmModalProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const SubmitConfirmModal: React.FC<SubmitConfirmModalProps> = ({ isOpen, onConfirm, onCancel }) => {
+  return (
+    <AlertDialog open={isOpen} onOpenChange={onCancel}>
+      <AlertDialogContent className="cyber-card border border-cyber-blue/20 bg-card/95 backdrop-blur-sm">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-yellow-400">경고</AlertDialogTitle>
+          <AlertDialogDescription className="text-gray-300">
+            테스트케이스를 전부 통과하지 못했습니다. 그래도 제출하시겠습니까?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="flex justify-center space-x-4">
+          <AlertDialogCancel asChild>
+            <CyberButton variant="secondary" onClick={onCancel} className="flex-1">
+              아니오
+            </CyberButton>
+          </AlertDialogCancel>
+          <AlertDialogAction asChild>
+            <CyberButton variant="destructive" onClick={onConfirm} className="flex-1">
+              예, 제출합니다
+            </CyberButton>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default SubmitConfirmModal;

--- a/src/pages/BattlePage.tsx
+++ b/src/pages/BattlePage.tsx
@@ -12,6 +12,7 @@ import { getLanguageConfig } from '@/utils/languageConfig';
 import { CodeEditorHandler } from '@/utils/codeEditorHandlers';
 import usePreventNavigation from '@/hooks/usePreventNavigation';
 import GameExitModal from '@/components/GameExitModal';
+import SubmitConfirmModal from '@/components/SubmitConfirmModal';
 import useWebSocketStore from '@/stores/websocketStore';
 import { authFetch } from '@/utils/api';
 import hljs from 'highlight.js/lib/core';
@@ -166,6 +167,7 @@ const BattlePage = () => {
   }, []);
   const chatEndRef = useRef<HTMLDivElement | null>(null);
   const [isExitModalOpen, setIsExitModalOpen] = useState(false);
+  const [isSubmitModalOpen, setIsSubmitModalOpen] = useState(false);
   const [confirmExitCallback, setConfirmExitCallback] = useState<(() => void) | null>(null);
   const [cancelExitCallback, setCancelExitCallback] = useState<(() => void) | null>(null);
 
@@ -554,8 +556,22 @@ const BattlePage = () => {
   };
 
   const handleSubmit = () => {
-    cleanupScreenShare(); // 코드 제출 시 화면 공유 중단
+    if (runStatus === '성공') {
+      cleanupScreenShare(); // 코드 제출 시 화면 공유 중단
+      navigate('/result');
+    } else {
+      setIsSubmitModalOpen(true);
+    }
+  };
+
+  const handleConfirmSubmit = () => {
+    setIsSubmitModalOpen(false);
+    cleanupScreenShare();
     navigate('/result');
+  };
+
+  const handleCancelSubmit = () => {
+    setIsSubmitModalOpen(false);
   };
 
   const toggleHint = () => {
@@ -921,6 +937,11 @@ const BattlePage = () => {
         isOpen={isExitModalOpen}
         onConfirmExit={handleConfirmExit}
         onCancelExit={handleCancelExit}
+      />
+      <SubmitConfirmModal
+        isOpen={isSubmitModalOpen}
+        onConfirm={handleConfirmSubmit}
+        onCancel={handleCancelSubmit}
       />
     </div>
   );

--- a/src/pages/BattlePage.tsx
+++ b/src/pages/BattlePage.tsx
@@ -495,6 +495,7 @@ const BattlePage = () => {
     setRunStatus(null);
 
     try {
+      const matchId = localStorage.getItem('currentMatchId');
       const response = await authFetch(
         `${apiUrl}/api/v1/game/submit`,
         {
@@ -507,6 +508,7 @@ const BattlePage = () => {
             language: "python",
             code,
             problem_id: `${problemId}`,
+            match_id: matchId,
           }),
         },
       );
@@ -532,10 +534,10 @@ const BattlePage = () => {
           if (line.startsWith("data:")) {
             const data = JSON.parse(line.slice(5));
             if (data.type === "progress") {
-              setExecutionResult(
+                setExecutionResult(
                 (prev) =>
-                  `${prev}\n[${data.index + 1}/${data.total}] stdout: ${data.result.stdout}`,
-              );
+                  `${prev}\n[${data.index + 1}/${data.total}] duration: ${Number(data.result.duration).toFixed(2)} ms, memoryUsed: ${data.result.memoryUsed} KB, status: ${data.result.status}`,
+                );
             } else if (data.type === "final") {
               setExecutionResult(
                 (prev) =>

--- a/src/pages/MatchingPage.tsx
+++ b/src/pages/MatchingPage.tsx
@@ -54,7 +54,8 @@ const MatchingPage = () => {
         setOpponentAccepted(false);
         setAcceptTimeLeft(message.time_limit);
         matchIdRef.current = message.match_id;
-        // You might want to update opponent details here based on message.opponent_ids
+        localStorage.setItem('currentMatchId', String(message.match_id));
+        // message.opponent_ids를 기반으로 상대방 정보를 여기서 업데이트할 수 있습니다.
       } else if (message.type === "match_accepted") {
         if (message.problem && message.game_id) {
           localStorage.setItem(
@@ -75,6 +76,7 @@ const MatchingPage = () => {
         setUserAccepted(false);
         setOpponentAccepted(false);
         matchIdRef.current = null;
+        localStorage.removeItem('currentMatchId');
         if (message.reason === "timeout or rejection") {
           navigate("/home"); // Go back to home or a suitable page
         }
@@ -135,6 +137,7 @@ const MatchingPage = () => {
       const message = { type: "match_accept", match_id: matchIdRef.current };
       console.log("Sending WebSocket message:", message);
       ws.send(JSON.stringify(message));
+      localStorage.setItem('currentMatchId', String(matchIdRef.current));
     } else {
       console.warn(
         "WebSocket not connected or matchId not set. ws:",
@@ -152,6 +155,7 @@ const MatchingPage = () => {
         JSON.stringify({ type: "match_reject", match_id: matchIdRef.current }),
       );
     }
+    localStorage.removeItem('currentMatchId');
     navigate("/home"); // Navigate away after declining
   };
 
@@ -159,6 +163,7 @@ const MatchingPage = () => {
     if (ws) {
       ws.send(JSON.stringify({ type: "cancel_queue" }));
     }
+    localStorage.removeItem('currentMatchId');
     navigate("/home"); // Navigate away after cancelling
   };
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f03a3095-e168-4b6d-a3b0-400df2fc7d91)

테스트케이스 구동 관련
- 인게임 코드 넣고 실행 시 `match_id`를 포함토록 함
- 인게임 우측하단 실행 결과에 실행 시간 (`duration`), 총 메모리 사용량 (`memoryUsed`), 실행 결과 (`status`)를 포함토록 함


![image](https://github.com/user-attachments/assets/62e6b1a5-4c69-46ec-a10b-2070fc792fca)

제출 관련
- 인게임 우측하단 "실행"을 눌러, 결과가 "성공"이 뜨면 즉시 제출 가능
- 그렇지 않은 경우 위와 같이 '그래도 제출하겠냐'는 확인 다이얼로그를 띄움
