### PR TITLE
✨  [FEAT] 상대방이 나간 후에도 문제 계속 풀기 기능 추가Detail

### DIFF
--- a/src/hooks/useBattleCodeEditor.ts
+++ b/src/hooks/useBattleCodeEditor.ts
@@ -95,7 +95,7 @@ export const useBattleCodeEditor = ({
     setRunStatus(null);
 
     try {
-      const matchId = localStorage.getItem('currentMatchId');
+      const matchId = sessionStorage.getItem('currentMatchId');
       const response = await authFetch(
         `${apiUrl}/api/v1/game/submit_public`,
         {
@@ -154,7 +154,7 @@ export const useBattleCodeEditor = ({
   const submitFinal = useCallback(async () => {
     setExecutionResult('코드를 제출하고 있습니다...');
     try {
-      const matchId = localStorage.getItem('currentMatchId');
+      const matchId = sessionStorage.getItem('currentMatchId');
       const response = await authFetch(
         `${apiUrl}/api/v1/game/submit`,
         {

--- a/src/hooks/useBattleModals.ts
+++ b/src/hooks/useBattleModals.ts
@@ -24,6 +24,7 @@ interface UseBattleModalsProps {
   setRemoteStream: (stream: MediaStream | null) => void;
   sharedPC: RTCPeerConnection | null;
   setPeerConnection: (pc: RTCPeerConnection | null) => void;
+  confirmNavigation?: () => void; // New prop
 }
 
 export const useBattleModals = ({
@@ -47,6 +48,7 @@ export const useBattleModals = ({
   setRemoteStream,
   sharedPC,
   setPeerConnection,
+  confirmNavigation, // confirmNavigation 추가
 }: UseBattleModalsProps) => {
   const navigate = useNavigate();
   const { sendMessage } = useWebSocketStore();
@@ -99,8 +101,12 @@ export const useBattleModals = ({
   const handleConfirmSubmit = useCallback(() => {
     setIsSubmitModalOpen(false);
     cleanupScreenShare();
-    navigate('/result');
-  }, [cleanupScreenShare, navigate]);
+    if (confirmNavigation) {
+      confirmNavigation();
+    } else {
+      navigate('/result');
+    }
+  }, [cleanupScreenShare, navigate, confirmNavigation]);
 
   const handleCancelSubmit = useCallback(() => {
     setIsSubmitModalOpen(false);
@@ -156,19 +162,27 @@ export const useBattleModals = ({
   }, [handleContinueAlone]);
 
   const handleSurrenderLeave = useCallback(() => {
-    const stored = localStorage.getItem('matchResult');
-    if (stored) {
-      navigate('/result', { state: { matchResult: JSON.parse(stored) } });
+    if (confirmNavigation) {
+      confirmNavigation();
     } else {
-      navigate('/result');
+      const stored = sessionStorage.getItem('matchResult');
+      if (stored) {
+        navigate('/result', { state: { matchResult: JSON.parse(stored) } });
+      } else {
+        navigate('/result');
+      }
     }
-  }, [navigate]);
+  }, [navigate, confirmNavigation]);
 
   const handleLeave = useCallback(() => {
     cleanupScreenShare();
     setShowOpponentLeftModal(false);
-    navigate('/waiting-room');
-  }, [cleanupScreenShare, navigate]);
+    if (confirmNavigation) {
+      confirmNavigation();
+    } else {
+      navigate('/waiting-room');
+    }
+  }, [cleanupScreenShare, navigate, confirmNavigation]);
 
   return {
     isExitModalOpen,

--- a/src/hooks/useBattleModals.ts
+++ b/src/hooks/useBattleModals.ts
@@ -15,6 +15,7 @@ interface UseBattleModalsProps {
   setShowLocalScreenSharePrompt: React.Dispatch<React.SetStateAction<boolean>>;
   setShowRemoteScreenSharePrompt: React.Dispatch<React.SetStateAction<boolean>>;
   setShowScreenSharePrompt: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowOpponentScreenShareRequiredModal: React.Dispatch<React.SetStateAction<boolean>>;
   reportCheating: (payload: any) => void; // Adjust payload type as needed
   // 추가된 속성들
   sharedLocalStream: MediaStream | null;
@@ -39,6 +40,7 @@ export const useBattleModals = ({
   setShowLocalScreenSharePrompt,
   setShowRemoteScreenSharePrompt,
   setShowScreenSharePrompt,
+  setShowOpponentScreenShareRequiredModal,
   reportCheating,
   // 추가된 속성들 구조 분해 할당
   sharedLocalStream,
@@ -141,6 +143,7 @@ export const useBattleModals = ({
     setShowLocalScreenSharePrompt(false); // 이 상태는 useBattleScreenShare에서 관리
     setShowRemoteScreenSharePrompt(false); // 이 상태는 useBattleWebRTC에서 관리
     setShowScreenSharePrompt(false); // 이 상태는 BattlePage에서 관리
+    setShowOpponentScreenShareRequiredModal(false);
 
     // WebRTC 연결 종료
     if (sharedPC) {

--- a/src/hooks/useBattleProblem.tsx
+++ b/src/hooks/useBattleProblem.tsx
@@ -12,9 +12,9 @@ export const useBattleProblem = (props?: UseBattleProblemProps) => {
   const problemId = problem?.problem_id ?? problem?.problem_id;
 
   useEffect(() => {
-    const gameId = searchParams.get('gameId') || localStorage.getItem('gameId');
+    const gameId = searchParams.get('gameId') || sessionStorage.getItem('gameId');
     if (gameId) {
-      const storedProblem = localStorage.getItem(`problem_${gameId}`);
+      const storedProblem = sessionStorage.getItem(`problem_${gameId}`);
       if (storedProblem) {
         try {
           const parsedProblem: ProblemWithImages = JSON.parse(storedProblem);
@@ -29,9 +29,9 @@ export const useBattleProblem = (props?: UseBattleProblemProps) => {
 
   useEffect(() => {
     const gameId =
-      searchParams.get('gameId') || localStorage.getItem('gameId');
+      searchParams.get('gameId') || sessionStorage.getItem('gameId');
     if (problem && gameId) {
-      localStorage.setItem(`problem_${gameId}`, JSON.stringify(problem));
+      sessionStorage.setItem(`problem_${gameId}`, JSON.stringify(problem));
     }
   }, [problem, searchParams]);
 

--- a/src/hooks/useBattleWebSocket.ts
+++ b/src/hooks/useBattleWebSocket.ts
@@ -24,6 +24,7 @@ interface UseBattleWebSocketProps {
   isRemoteStreamActive: boolean;
   setShowOpponentScreenShareRequiredModal: React.Dispatch<React.SetStateAction<boolean>>;
   setOpponentScreenShareCountdown: React.Dispatch<React.SetStateAction<number>>;
+  isSolvingAlone: boolean;
 }
 
 export const useBattleWebSocket = ({
@@ -46,6 +47,7 @@ export const useBattleWebSocket = ({
   isRemoteStreamActive,
   setShowOpponentScreenShareRequiredModal,
   setOpponentScreenShareCountdown,
+  isSolvingAlone,
 }: UseBattleWebSocketProps) => {
   const { websocket, connect } = useWebSocketStore();
   const { user } = useUser();
@@ -141,6 +143,7 @@ export const useBattleWebSocket = ({
           navigate('/result');
         } else if (data.type === 'opponent_left') {
           setIsGameFinished(true);
+          setShowScreenShareRequiredModal(false);
           setShowOpponentLeftModal(true);
           setChatMessages((prev) => [
             ...prev,
@@ -151,6 +154,7 @@ export const useBattleWebSocket = ({
             },
           ]);
         } else if (data.type === 'opponent_rejoined') {
+          if (isSolvingAlone) return;
           console.log('Received opponent_rejoined message:', data);
           setShowOpponentLeftModal(false);
           setIsRemoteStreamActive(false);
@@ -177,7 +181,7 @@ export const useBattleWebSocket = ({
               type: 'system',
             },
           ]);
-          if (!isMe) {
+          if (!isMe && !isSolvingAlone) {
             setIsRemoteStreamActive(false);
             setShowRemoteScreenSharePrompt(true);
             setIsGamePaused(true); // 상대방 화면 공유 중단 시 게임 일시 정지
@@ -197,7 +201,7 @@ export const useBattleWebSocket = ({
                 return prev - 1;
               });
             }, 1000);
-          } else {
+          } else if (isMe) {
             // 자신이 화면 공유를 중지한 경우
             console.log("Setting showScreenShareRequiredModal to true.");
             setShowScreenShareRequiredModal(true);
@@ -263,7 +267,7 @@ export const useBattleWebSocket = ({
       }
     };
 
-  }, [websocket, user, handleSignal, navigate, setChatMessages, setIsGameFinished, setShowOpponentLeftModal, setIsRemoteStreamActive, setShowRemoteScreenSharePrompt, setIsGamePaused, setShowScreenShareRequiredModal, setScreenShareCountdown, screenShareCountdownIntervalRef, setProblem, sendMessage, cleanupScreenShare, isLocalStreamActive, isRemoteStreamActive, setShowOpponentScreenShareRequiredModal, setOpponentScreenShareCountdown]);
+  }, [websocket, user, handleSignal, navigate, setChatMessages, setIsGameFinished, setShowOpponentLeftModal, setIsRemoteStreamActive, setShowRemoteScreenSharePrompt, setIsGamePaused, setShowScreenShareRequiredModal, setScreenShareCountdown, screenShareCountdownIntervalRef, setProblem, sendMessage, cleanupScreenShare, isLocalStreamActive, isRemoteStreamActive, setShowOpponentScreenShareRequiredModal, setOpponentScreenShareCountdown, isSolvingAlone]);
 
   useEffect(() => {
     return () => {

--- a/src/hooks/useBattleWebSocket.ts
+++ b/src/hooks/useBattleWebSocket.ts
@@ -59,7 +59,7 @@ export const useBattleWebSocket = ({
     : apiUrl.replace(/^http/, 'ws');
 
   useEffect(() => {
-    const storedWebsocketUrl = localStorage.getItem('websocketUrl');
+    const storedWebsocketUrl = sessionStorage.getItem('websocketUrl');
     let currentWsUrl: string | null = null;
 
     if (storedWebsocketUrl) {
@@ -127,7 +127,7 @@ export const useBattleWebSocket = ({
         } else if (data.type === 'match_result') {
           console.log('BattlePage: Match result received:', data);
           try {
-            localStorage.setItem('matchResult', JSON.stringify(data));
+            sessionStorage.setItem('matchResult', JSON.stringify(data));
             if (data.reason === 'surrender' && data.winner === user.user_id) {
               setIsGameFinished(true);
               setShowSurrenderModal(true);

--- a/src/hooks/useMatching.ts
+++ b/src/hooks/useMatching.ts
@@ -52,14 +52,14 @@ export function useMatching() {
             setOpponentAccepted(false);
             setAcceptTimeLeft(message.time_limit);
             matchIdRef.current = message.match_id;
-            localStorage.setItem("currentMatchId", String(message.match_id));
+            sessionStorage.setItem("currentMatchId", String(message.match_id));
             // 상대 정보 동적으로 들어올 경우 여기에 setOpponent(message.opponent)
         } else if (message.type === "match_accepted") {
             if (message.problem && message.game_id) {
             try {
                 fetchProblemForGame(message.problem, message.game_id);
                 setOpponentAccepted(true);
-                localStorage.setItem("gameId", message.game_id);
+                sessionStorage.setItem("gameId", message.game_id);
                 navigate(`/screen-share-setup?gameId=${message.game_id}`);
             } catch (error) {
                 navigate("/home");
@@ -135,7 +135,7 @@ export function useMatching() {
         ws.send(
             JSON.stringify({ type: "match_accept", match_id: matchIdRef.current })
         );
-        localStorage.setItem("currentMatchId", String(matchIdRef.current));
+        sessionStorage.setItem("currentMatchId", String(matchIdRef.current));
     }
     };
 

--- a/src/hooks/usePreventNavigation.ts
+++ b/src/hooks/usePreventNavigation.ts
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 interface UsePreventNavigationOptions {
   shouldPrevent: boolean;
   onAttemptNavigation: (confirm: () => void, cancel: () => void) => void;
+  onNavigationConfirmed?: () => void; // New optional callback
 }
 
 const usePreventNavigation = ({ shouldPrevent, onAttemptNavigation }: UsePreventNavigationOptions) => {

--- a/src/hooks/useScreenShareSetup.ts
+++ b/src/hooks/useScreenShareSetup.ts
@@ -38,7 +38,7 @@ export function useScreenShareSetup() {
   // --- Game ID/유저 ID 관리 ---
   const gameId = searchParams.get("gameId");
   const currentUrlGameId = searchParams.get("gameId");
-  const storedGameId = localStorage.getItem("currentGameId");
+  const storedGameId = sessionStorage.getItem("currentGameId");
   const effectiveGameId = currentUrlGameId || storedGameId;
   const userId = user?.user_id;
 

--- a/src/pages/BattlePage.tsx
+++ b/src/pages/BattlePage.tsx
@@ -233,6 +233,7 @@ const BattlePage = () => {
     setShowLocalScreenSharePrompt,
     setShowRemoteScreenSharePrompt,
     setShowScreenSharePrompt,
+    setShowOpponentScreenShareRequiredModal,
     sharedPC,
     setPeerConnection,
     reportCheating,
@@ -258,6 +259,7 @@ const BattlePage = () => {
     isRemoteStreamActive,
     setShowOpponentScreenShareRequiredModal,
     setOpponentScreenShareCountdown,
+    isSolvingAlone,
   });
 
   // usePreventNavigation hook

--- a/src/pages/BattlePage.tsx
+++ b/src/pages/BattlePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useUser } from "@/context/UserContext";
 import CyberCard from "@/components/CyberCard";
@@ -40,6 +40,7 @@ import { ScreenShareRequiredModal } from "@/components/ScreenShareRequiredModal"
 import hljs from "highlight.js/lib/core";
 import python from "highlight.js/lib/languages/python";
 import "highlight.js/styles/vs2015.css";
+import { useToast } from "@/components/ui/use-toast"; // useToast 임포트
 
 // Custom Hooks
 import { useBattleWebRTC } from "@/hooks/useBattleWebRTC";
@@ -68,6 +69,7 @@ const BattlePage = () => {
   const [searchParams] = useSearchParams();
   const gameId = searchParams.get("gameId");
   const { websocket, sendMessage, disconnect, connect } = useWebSocketStore();
+  const { toast } = useToast(); // useToast 훅 사용
 
   // Refs that remain in BattlePage
   const localVideoRef = useRef<HTMLVideoElement | null>(null);
@@ -82,6 +84,19 @@ const BattlePage = () => {
   const [showScreenSharePrompt, setShowScreenSharePrompt] = useState(false);
   const [showOpponentScreenShareRequiredModal, setShowOpponentScreenShareRequiredModal] = useState(false);
   const [opponentScreenShareCountdown, setOpponentScreenShareCountdown] = useState(0);
+
+  // gameId 유효성 검사 및 리다이렉트
+  useEffect(() => {
+    const storedGameId = sessionStorage.getItem("gameId");
+    if (!storedGameId) {
+      toast({
+        title: "잘못된 접근",
+        description: "유효한 게임 정보가 없습니다. 홈으로 이동합니다.",
+        variant: "destructive",
+      });
+      navigate("/home");
+    }
+  }, [navigate, toast]);
 
   // Custom Hook Calls
   const { reportCheating } = useCheatDetection({
@@ -246,13 +261,24 @@ const BattlePage = () => {
   });
 
   // usePreventNavigation hook
-  usePreventNavigation({
+  const { confirmNavigation } = usePreventNavigation({
     shouldPrevent: true,
     onAttemptNavigation: (confirm, cancel) => {
       setIsExitModalOpen(true);
       setConfirmExitCallback(() => confirm);
       setCancelExitCallback(() => cancel);
     },
+    onNavigationConfirmed: useCallback(() => {
+      // 배틀 페이지 관련 로컬 스토리지 데이터 제거
+      localStorage.removeItem("currentMatchId");
+      localStorage.removeItem("gameId");
+      localStorage.removeItem("matchResult");
+      localStorage.removeItem("websocketUrl");
+      localStorage.removeItem("currentGameId");
+      if (gameId) {
+        localStorage.removeItem(`problem_${gameId}`);
+      }
+    }, [gameId]), // gameId를 종속성 배열에 추가
   });
 
   // Effect for localVideoRef and remoteVideoRef srcObject

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -55,6 +55,20 @@ const ResultPage = () => {
   const matchResult = location.state?.matchResult as MatchResult | null;
 
   useEffect(() => {
+    // problem_{gameId} 제거 (동적 키)를 위해 gameId를 먼저 가져옴
+    const gameId = sessionStorage.getItem("gameId");
+
+    // 배틀 페이지 관련 세션 스토리지 데이터 제거
+    sessionStorage.removeItem("currentMatchId");
+    sessionStorage.removeItem("gameId");
+    sessionStorage.removeItem("matchResult");
+    sessionStorage.removeItem("websocketUrl");
+    sessionStorage.removeItem("currentGameId");
+
+    if (gameId) {
+      sessionStorage.removeItem(`problem_${gameId}`);
+    }
+
     console.log('ResultPage: Match result from state:', matchResult);
 
     if (!matchResult) {

--- a/src/pages/ScreenShareSetupPage.tsx
+++ b/src/pages/ScreenShareSetupPage.tsx
@@ -38,7 +38,7 @@ const ScreenShareSetupPage = () => {
 
   // effectiveGameId와 userId를 컴포넌트 최상위 레벨에서 정의
   const currentUrlGameId = searchParams.get('gameId');
-  const storedGameId = localStorage.getItem('currentGameId');
+  const storedGameId = sessionStorage.getItem('currentGameId');
   const effectiveGameId = currentUrlGameId || storedGameId;
   const userId = user?.user_id;
 
@@ -206,7 +206,7 @@ const ScreenShareSetupPage = () => {
 
   useEffect(() => {
     const currentUrlGameId = searchParams.get('gameId');
-    const storedGameId = localStorage.getItem('currentGameId');
+    const storedGameId = sessionStorage.getItem('currentGameId');
     const userId = user?.user_id;
 
     let effectiveGameId = null;

--- a/src/pages/matching/components/OpponentInfo.tsx
+++ b/src/pages/matching/components/OpponentInfo.tsx
@@ -1,9 +1,32 @@
 import React from 'react';
 
-const OpponentInfo = () => {
+interface OpponentInfoProps {
+  userAccepted: boolean;
+  opponentAccepted: boolean;
+  opponent: {
+    name: string;
+    rank: string;
+  };
+}
+
+const OpponentInfo: React.FC<OpponentInfoProps> = ({
+  userAccepted,
+  opponentAccepted,
+  opponent,
+}) => {
   return (
-    <div>
-      {/* Opponent information will be displayed here */}
+    <div className="flex flex-col items-center justify-center space-y-2">
+      <h2 className="text-xl font-bold text-cyber-green">상대방 정보</h2>
+      <p className="text-lg text-cyber-blue">이름: {opponent.name}</p>
+      <p className="text-lg text-cyber-blue">랭크: {opponent.rank}</p>
+      <div className="flex space-x-4 mt-2">
+        <span className={`text-md ${userAccepted ? 'text-green-400' : 'text-red-400'}`}>
+          나: {userAccepted ? '수락' : '대기중'}
+        </span>
+        <span className={`text-md ${opponentAccepted ? 'text-green-400' : 'text-red-400'}`}>
+          상대방: {opponentAccepted ? '수락' : '대기중'}
+        </span>
+      </div>
     </div>
   );
 };

--- a/src/pages/not-found/NotFound.tsx
+++ b/src/pages/not-found/NotFound.tsx
@@ -12,6 +12,20 @@ const NotFound = () => {
       "404 Error: User attempted to access non-existent route:",
       location.pathname,
     );
+
+    // problem_{gameId} 제거 (동적 키)를 위해 gameId를 먼저 가져옴
+    const gameId = sessionStorage.getItem("gameId");
+
+    // 배틀 페이지 관련 세션 스토리지 데이터 제거
+    sessionStorage.removeItem("currentMatchId");
+    sessionStorage.removeItem("gameId");
+    sessionStorage.removeItem("matchResult");
+    sessionStorage.removeItem("websocketUrl");
+    sessionStorage.removeItem("currentGameId");
+
+    if (gameId) {
+      sessionStorage.removeItem(`problem_${gameId}`);
+    }
   }, [location.pathname]);
 
   return (

--- a/src/stores/websocketStore.ts
+++ b/src/stores/websocketStore.ts
@@ -22,7 +22,7 @@ const useWebSocketStore = create<WebSocketState>((set, get) => ({
   maxReconnectAttempts: 5,
   reconnectTimeoutId: null,
   isReconnecting: false,
-  reconnectUrl: localStorage.getItem('websocketUrl'), // Load from localStorage on init
+  reconnectUrl: sessionStorage.getItem('websocketUrl'), // Load from sessionStorage on init
 
   connect: (url: string) => {
     const { websocket, isReconnecting, reconnectTimeoutId } = get();
@@ -53,7 +53,7 @@ const useWebSocketStore = create<WebSocketState>((set, get) => ({
 
     ws.onopen = () => {
       console.log('WebSocket connected.');
-      localStorage.setItem('websocketUrl', url); // Save URL to localStorage on successful connection
+      sessionStorage.setItem('websocketUrl', url); // Save URL to sessionStorage on successful connection
       set({ websocket: ws, isConnected: true, reconnectAttempts: 0, isReconnecting: false });
     };
 


### PR DESCRIPTION
## 상대방이 항복하거나 연결을 끊어 배틀을 떠난 후에도 사용자가 계속해서 문제를 풀 수 있는 기능을 추가했습니다.

주요 변경 사항:
- 상대방이 나가면 사용자에게 계속 풀기 또는 나가기 옵션을 제공하는 모달이 표시됩니다.
- 사용자가 계속 풀기를 선택하면 "혼자 풀기" 모드로 전환됩니다.
- "혼자 풀기" 모드에서는 다음이 적용됩니다.
    - 모든 WebRTC 연결 및 화면 공유가 종료됩니다.
   - 상대방의 비디오 피드가 제거되는 등 UI가 혼자 풀기 모드에 맞게 업데이트됩니다.
   - "상대방의 화면 공유를 기다리는 중" 모달이 표시되지 않도록 수정했습니다.
- `usePreventNavigation` 훅을 통합하여 페이지를 나갈 때 네비게이션 확인을 처리하도록 했습니다.
- 배틀 관련 데이터 저장소를 `localStorage`에서 `sessionStorage`로 변경하여 세션이
      종료될 때 데이터가 삭제되도록 했습니다.