### PR TITLE
:bug: [FEAT] 프로필 이미지 S3 URL 조합 처리 로직 추가

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
 VITE_API_URL=http://localhost:8000
+VITE_S3_BASE_URL=https://codeground-profile.s3.ap-northeast-2.amazonaws.com

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 VITE_API_URL=https://api.code-ground.com
+VITE_S3_BASE_URL=https://codeground-profile.s3.ap-northeast-2.amazonaws.com

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -21,3 +21,11 @@ export function getCookie(name: string): string | null {
 export function eraseCookie(name: string) {
   document.cookie = name + "=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;";
 }
+
+const S3_BASE_URL = import.meta.env.VITE_S3_BASE_URL;
+
+export const getAbsoluteUrl = (path: string) => {
+  if (!path) return "";
+  if (path.startsWith("http")) return path;
+  return `${S3_BASE_URL}/${path}`;
+};

--- a/src/pages/home/components/ProfileSummaryCard.tsx
+++ b/src/pages/home/components/ProfileSummaryCard.tsx
@@ -22,12 +22,15 @@ const ProfileSummaryCard = ({ user, onViewProfile }: Props) => {
   const { tier, lp } = parseTotalScore(user.totalScore);
   const winRate = user.win_rate != null ? user.win_rate.toFixed(2) : "0.00";
 
+  const S3_BASE_URL = "https://codeground-profile.s3.ap-northeast-2.amazonaws.com";
+  const profileImageUrl = user.profileImageUrl ? `${S3_BASE_URL}/${user.profileImageUrl}` : undefined;
+
   return (
     <CyberCard className="text-center">
       {/* 1. 프로필 이미지 */}
       <div className="w-20 h-20 rounded-full mx-auto mb-2 overflow-hidden bg-cyber-dark flex items-center justify-center border-2 border-cyber-blue">
-        {user.profileImageUrl ? (
-          <img src={user.profileImageUrl} alt="프로필 이미지" className="h-full w-full object-cover" />
+        {profileImageUrl ? (
+          <img src={profileImageUrl} alt="프로필 이미지" className="h-full w-full object-cover" />
         ) : (
           <Users className="h-10 w-10 text-white" />
         )}
@@ -42,15 +45,14 @@ const ProfileSummaryCard = ({ user, onViewProfile }: Props) => {
           <img src={tier.image} alt={tier.name} className="h-20 w-20 object-contain" />
         )}
       </div>
-      {/* 4. V 0 LP (현재 LP) */}
+      {/* 4. 티어 + LP */}
       <div className="text-center mb-1">
         <span className="text-lg font-bold text-white">
           <span className={tier.color}>{tier.name}</span> • {user.rank}위
         </span>
         <div className="text-lg font-bold text-cyber-blue">{lp} LP</div>
-        {/* <span className="text-sm text-gray-400 ml-2">(현재 LP)</span> */}
       </div>
-      {/* 6. 승/패/승률 */}
+      {/* 5. 승/패/승률 */}
       <div className="grid grid-cols-3 gap-2 text-center mb-4">
         <div>
           <div className="text-lg font-bold text-green-400">{user.win}</div>
@@ -65,7 +67,7 @@ const ProfileSummaryCard = ({ user, onViewProfile }: Props) => {
           <div className="text-sm text-gray-400">승률</div>
         </div>
       </div>
-      {/* 7. 프로필 보기 버튼 */}
+      {/* 6. 프로필 보기 버튼 */}
       <CyberButton className="w-full" onClick={onViewProfile}>
         프로필 보기
       </CyberButton>

--- a/src/pages/home/components/ProfileSummaryCard.tsx
+++ b/src/pages/home/components/ProfileSummaryCard.tsx
@@ -2,6 +2,7 @@ import CyberCard from "@/components/CyberCard";
 import CyberButton from "@/components/CyberButton";
 import { Users } from "lucide-react";
 import { parseTotalScore } from "@/utils/lpSystem";
+import { getAbsoluteUrl } from "@/lib/utils";
 
 interface UserStats {
   nickname: string;
@@ -22,8 +23,7 @@ const ProfileSummaryCard = ({ user, onViewProfile }: Props) => {
   const { tier, lp } = parseTotalScore(user.totalScore);
   const winRate = user.win_rate != null ? user.win_rate.toFixed(2) : "0.00";
 
-  const S3_BASE_URL = "https://codeground-profile.s3.ap-northeast-2.amazonaws.com";
-  const profileImageUrl = user.profileImageUrl ? `${S3_BASE_URL}/${user.profileImageUrl}` : undefined;
+  const profileImageUrl = getAbsoluteUrl(user.profileImageUrl);
 
   return (
     <CyberCard className="text-center">

--- a/src/pages/login/components/OAuthCallback.tsx
+++ b/src/pages/login/components/OAuthCallback.tsx
@@ -2,6 +2,7 @@ import React, {useEffect} from "react";
 import {useLocation, useNavigate} from "react-router-dom";
 import {useUser} from "../../../context/UserContext";
 import {authFetch} from "../../../utils/api";
+import { getAbsoluteUrl } from "@/lib/utils";
 
 const OAuthCallback = () => {
     const location = useLocation();
@@ -25,6 +26,7 @@ const OAuthCallback = () => {
 
                 setUser({
                     ...userData,
+                    profileImageUrl: getAbsoluteUrl(userData.profile_image_url),
                     totalScore: userData.user_mmr,
                     name: userData.nickname || userData.username,
                 });

--- a/src/pages/login/components/OAuthCallback.tsx
+++ b/src/pages/login/components/OAuthCallback.tsx
@@ -1,53 +1,56 @@
-import React, { useEffect } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
-import { useUser } from "../../../context/UserContext";
-import { authFetch } from "../../../utils/api";
+import React, {useEffect} from "react";
+import {useLocation, useNavigate} from "react-router-dom";
+import {useUser} from "../../../context/UserContext";
+import {authFetch} from "../../../utils/api";
 
 const OAuthCallback = () => {
-  const location = useLocation();
-  const navigate = useNavigate();
-  const { setUser } = useUser();
+    const location = useLocation();
+    const navigate = useNavigate();
+    const {setUser} = useUser();
 
-  useEffect(() => {
-    const handleOAuthCallback = async () => {
-      const params = new URLSearchParams(location.search);
-      const isNewUser = params.get("is_new_user") === "true";
+    useEffect(() => {
+        const handleOAuthCallback = async () => {
+            const params = new URLSearchParams(location.search);
+            const isNewUser = params.get("is_new_user") === "true";
 
-      try {
-        const userResponse = await authFetch(`/api/v1/user/me`);
+            try {
+                const userResponse = await authFetch(`/api/v1/user/me`);
 
-        if (userResponse.ok) {
-          const userData = await userResponse.json();
-          setUser({
-            ...userData,
-            totalScore: userData.user_mmr,
-            name: userData.nickname || userData.username,
-          });
+                const contentType = userResponse.headers.get("content-type") || "";
+                if (!userResponse.ok || !contentType.includes("application/json")) {
+                    throw new Error("서버 응답이 JSON이 아닙니다.");
+                }
 
-          if (isNewUser) {
-            navigate("/setup-profile");
-          } else {
-            navigate("/home");
-          }
-        } else {
-          throw new Error("Failed to fetch user profile.");
-        }
-      } catch (error) {
-        console.error("OAuth 처리 중 예외:", error);
-        navigate(
-          `/login?error=network_error&message=OAuth 처리 중 오류가 발생했습니다.`
-        );
-      }
-    };
+                const userData = await userResponse.json();
 
-    handleOAuthCallback();
-  }, [location, navigate, setUser]);
+                setUser({
+                    ...userData,
+                    totalScore: userData.user_mmr,
+                    name: userData.nickname || userData.username,
+                });
 
-  return (
-    <div className="min-h-screen flex items-center justify-center text-white text-lg">
-      GitHub 로그인 처리 중...
-    </div>
-  );
+                if (isNewUser) {
+                    navigate("/setup-profile");
+                } else {
+                    navigate("/home");
+                }
+            } catch (error) {
+                console.error("OAuth 처리 중 예외:", error);
+                navigate(
+                    `/login?error=network_error&message=OAuth 처리 중 오류가 발생했습니다.`
+                );
+            }
+        };
+
+
+        handleOAuthCallback();
+    }, [location, navigate, setUser]);
+
+    return (
+        <div className="min-h-screen flex items-center justify-center text-white text-lg">
+            GitHub 로그인 처리 중...
+        </div>
+    );
 };
 
 export default OAuthCallback;

--- a/src/pages/profile/components/UserInfoCard.tsx
+++ b/src/pages/profile/components/UserInfoCard.tsx
@@ -4,34 +4,40 @@ import { User } from "lucide-react";
 
 interface Props {
   nickname: string;
-  profileImageUrl?: string;
+  profileImageUrl?: string;  // 상대 경로로 들어옴: "profile_images/xxx.png"
   rank: number;
   tier: { name: string; color: string };
   lp: number;
   onEdit: () => void;
 }
 
-const UserInfoCard = ({nickname, profileImageUrl, rank, tier, lp, onEdit }: Props) => (
-  <CyberCard className="text-center">
-    <div className="w-24 h-24 bg-gradient-to-r from-cyber-blue to-cyber-purple rounded-full mx-auto mb-4 flex items-center justify-center overflow-hidden border-2 border-cyber-blue">
-      {profileImageUrl ? (
-        <img src={profileImageUrl} alt={nickname} className="w-full h-full object-cover" />
-      ) : (
-        <User className="h-12 w-12 text-white" />
-      )}
-    </div>
-    <h1 className="text-2xl font-bold text-white mb-2">{nickname}</h1>
-    <div className="text-gray-400 text-sm mb-4">
-      <span className={tier.color}>{tier.name}</span> • 전체랭킹 {rank}위
-    </div>
-    <div className="text-center mb-4">
-      <div className="text-lg font-bold text-cyber-blue">{lp} LP</div>
-      <div className="text-sm text-gray-400">총 포인트</div>
-    </div>
-    <CyberButton onClick={onEdit} className="w-full">
-      프로필 편집
-    </CyberButton>
-  </CyberCard>
-);
+const UserInfoCard = ({ nickname, profileImageUrl: rawUrl, rank, tier, lp, onEdit }: Props) => {
+  const S3_BASE_URL = "https://codeground-profile.s3.ap-northeast-2.amazonaws.com";
+  const profileImageUrl =
+    rawUrl && !rawUrl.startsWith("http") ? `${S3_BASE_URL}/${rawUrl}` : rawUrl;
+
+  return (
+    <CyberCard className="text-center">
+      <div className="w-24 h-24 bg-gradient-to-r from-cyber-blue to-cyber-purple rounded-full mx-auto mb-4 flex items-center justify-center overflow-hidden border-2 border-cyber-blue">
+        {profileImageUrl ? (
+          <img src={profileImageUrl} alt={nickname} className="w-full h-full object-cover" />
+        ) : (
+          <User className="h-12 w-12 text-white" />
+        )}
+      </div>
+      <h1 className="text-2xl font-bold text-white mb-2">{nickname}</h1>
+      <div className="text-gray-400 text-sm mb-4">
+        <span className={tier.color}>{tier.name}</span> • 전체랭킹 {rank}위
+      </div>
+      <div className="text-center mb-4">
+        <div className="text-lg font-bold text-cyber-blue">{lp} LP</div>
+        <div className="text-sm text-gray-400">총 포인트</div>
+      </div>
+      <CyberButton onClick={onEdit} className="w-full">
+        프로필 편집
+      </CyberButton>
+    </CyberCard>
+  );
+};
 
 export default UserInfoCard;

--- a/src/pages/profile/components/UserInfoCard.tsx
+++ b/src/pages/profile/components/UserInfoCard.tsx
@@ -1,5 +1,6 @@
 import CyberCard from "@/components/CyberCard";
 import CyberButton from "@/components/CyberButton";
+import { getAbsoluteUrl } from "@/lib/utils";
 import { User } from "lucide-react";
 
 interface Props {
@@ -12,9 +13,7 @@ interface Props {
 }
 
 const UserInfoCard = ({ nickname, profileImageUrl: rawUrl, rank, tier, lp, onEdit }: Props) => {
-  const S3_BASE_URL = "https://codeground-profile.s3.ap-northeast-2.amazonaws.com";
-  const profileImageUrl =
-    rawUrl && !rawUrl.startsWith("http") ? `${S3_BASE_URL}/${rawUrl}` : rawUrl;
+  const profileImageUrl = getAbsoluteUrl(rawUrl);
 
   return (
     <CyberCard className="text-center">

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+  readonly VITE_S3_BASE_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
🔸 UserInfoCard.tsx
- profileImageUrl가 S3 key인 경우를 고려해 `S3_BASE_URL`과 조합해서 실제 이미지 URL 구성
- S3 key가 이미 http로 시작하는 전체 URL인 경우는 그대로 사용

🔸 ProfileSummaryCard.tsx
- `user.profileImageUrl` 값이 S3 key일 경우를 대비해 프론트에서 S3 BASE URL과 조합 처리
- 백엔드에서 전체 URL을 내려주지 않더라도 프론트에서 안전하게 처리 가능하도록 수정