### PR TITLE
🎨 [STYLE] 실행 결과창 조정, 매칭 시 수락&거절 버튼

### DIFF
--- a/src/components/BattleCodeEditorPanel.tsx
+++ b/src/components/BattleCodeEditorPanel.tsx
@@ -95,7 +95,7 @@ const BattleCodeEditorPanel = ({
       </ResizablePanel>
       <ResizableHandle withHandle />
       <ResizablePanel defaultSize={25} minSize={15}>
-        <CyberCard className="h-full flex flex-col ml-2 mt-1">
+        <CyberCard className="h-full flex flex-col ml-2 mt-1 mb-[1px] overflow-hidden">
           <div className="flex items-center justify-between px-3 py-1 border-b border-gray-700/50">
             <h3 className="text-sm font-semibold text-cyber-blue">
               실행 결과
@@ -132,7 +132,7 @@ const BattleCodeEditorPanel = ({
               </CyberButton>
             </div>
           </div>
-          <div className="flex-1 p-2">
+          <div className="h-full flex-1 p-2"  style={{  overflowY: "auto" }}>
             <div className="h-full bg-black/30 border border-gray-700 rounded p-3 overflow-auto">
               <pre className="font-mono text-xs text-gray-300 whitespace-pre-wrap break-words">
                 {executionResult}

--- a/src/components/BattleCodeEditorPanel.tsx
+++ b/src/components/BattleCodeEditorPanel.tsx
@@ -95,7 +95,7 @@ const BattleCodeEditorPanel = ({
       </ResizablePanel>
       <ResizableHandle withHandle />
       <ResizablePanel defaultSize={25} minSize={15}>
-        <CyberCard className="h-full flex flex-col ml-2 mt-1 mb-[1px] overflow-hidden">
+        <CyberCard className="h-[calc(100%-4px)] flex flex-col ml-2 mt-1 mb-[1px] overflow-hidden">
           <div className="flex items-center justify-between px-3 py-1 border-b border-gray-700/50">
             <h3 className="text-sm font-semibold text-cyber-blue">
               실행 결과
@@ -132,7 +132,7 @@ const BattleCodeEditorPanel = ({
               </CyberButton>
             </div>
           </div>
-          <div className="h-full flex-1 p-2"  style={{  overflowY: "auto" }}>
+          <div className="h-full flex-1 p-2 pt-1"  style={{  overflowY: "auto" }}>
             <div className="h-full bg-black/30 border border-gray-700 rounded p-3 overflow-auto">
               <pre className="font-mono text-xs text-gray-300 whitespace-pre-wrap break-words">
                 {executionResult}

--- a/src/pages/matching/components/MatchFoundModal.tsx
+++ b/src/pages/matching/components/MatchFoundModal.tsx
@@ -58,7 +58,7 @@ const MatchFoundModal: React.FC<MatchFoundModalProps> = ({
                         <CyberButton
                             onClick={handleAccept}
                             size="lg"
-                            className="w-32 h-16 text-lg bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-400 hover:to-emerald-500"
+                            className="w-32 h-16 text-lg whitespace-nowrap bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-400 hover:to-emerald-500 overflow-hidden"
                         >
                             <Check className="h-6 w-6" />
                             수락
@@ -67,7 +67,7 @@ const MatchFoundModal: React.FC<MatchFoundModalProps> = ({
                             onClick={handleDecline}
                             variant="danger"
                             size="lg"
-                            className="w-32 h-16 text-lg"
+                            className="w-32 h-16 text-lg whitespace-nowrap "
                         >
                             <X className="h-6 w-6" />
                             거절


### PR DESCRIPTION
기초적인 임플란트입니다.


<img width="597" height="661" alt="image" src="https://github.com/user-attachments/assets/3e97917b-c6cc-4267-a6ed-fa5f3329c4cd" />

- 수락, 거절 버튼은 이제 
```
수
락
```

- ...처럼 나오지 않습니다.

<img width="810" height="267" alt="image" src="https://github.com/user-attachments/assets/9c7e8723-ad1f-49dc-bfcf-6b3afd0f1169" />

- 실행 결과란의 스크롤 기능을 부활시켰습니다.