### PR TITLE
🐛 [FIX] 제출 시 무조건 확인창이 뜨던 현상

### DIFF
--- a/src/hooks/useBattleCodeEditor.ts
+++ b/src/hooks/useBattleCodeEditor.ts
@@ -222,9 +222,16 @@ export const useBattleCodeEditor = ({
 
   const handleSubmit = useCallback(() => {
     // 제출 버튼을 누르면 항상 확인 모달을 띄웁니다.
-    setIsSubmitModalOpen(true);
-  }, []);
-
+  //   setIsSubmitModalOpen(true);
+  // }, []);
+    if (runStatus === "성공") {
+      // 테스트케이스들을 모두 통과한 경우 바로 제출합니다.
+      submitFinal();
+    } else {
+      // 통과하지 못한 경우 확인 모달을 표시합니다.
+      setIsSubmitModalOpen(true);
+    }
+  }, [runStatus, submitFinal]);
 
   const handleConfirmSubmit = useCallback(() => {
     // 모달에서 확인을 누르면 제출 로직을 실행합니다.


### PR DESCRIPTION
<img width="547" height="192" alt="image" src="https://github.com/user-attachments/assets/71e4d835-0f97-4a34-9741-efba6b4235b8" />

- 이전에는 "제출" 클릭 시 위 모달창이 항상 떴으나, 이제는 "실행" 클릭 후 공개 테스트케이스가 "성공"일 때는 해당 모달창이 뜨지 않고 즉시 제출됩니다.