### PR TITLE
✨ [FEAT] 어드민 대시보드(유저/신고/문제/업적 관리) 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ const ProfilePage = lazy(() => import("./pages/profile/ProfilePage"));
 const SettingsPage = lazy(() => import("./pages/settings/SettingsPage"));
 const CreateProblemPage = lazy(() => import("./pages/CreateProblemPage"));
 const UploadProblemPage = lazy(() => import("./pages/UploadProblemPage"));
+const AdminPage = lazy(() => import("./pages/admin/AdminPage")); // 관리자 페이지 import 추가
 const NotFound = lazy(() => import("./pages/not-found/NotFound"));
 const OAuthCallback = lazy(
   () => import("./pages/login/components/OAuthCallback")
@@ -113,15 +114,15 @@ const App = () => {
                       { path: "/profile", element: <ProfilePage /> },
                       { path: "/settings", element: <SettingsPage /> },
                       { path: "/create-problem", element:<CreateProblemPage />},
-                      { path: "/upload-problem", element:<UploadProblemPage />}
-                    ].map(({ path, element }) => (
+                      { path: "/upload-problem", element:<UploadProblemPage />},
+                      { path: "/admin", element: <AdminPage />, adminOnly: true } // 관리자 페이지 라우트 추가
+                    ].map(({ path, element, adminOnly }) => (
                       <Route
                         key={path}
                         path={path}
-                        element={<ProtectedRoute>{element}</ProtectedRoute>}
+                        element={<ProtectedRoute adminOnly={adminOnly}>{element}</ProtectedRoute>}
                       />
                     ))}
-                    <Route path="*" element={<NotFound />} />
                   </Routes>
                 </NavigationHandler>
               </Suspense>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -93,6 +93,15 @@ const Header = () => {
                     <Settings className="mr-2 h-4 w-4" />
                     설정
                   </DropdownMenuItem>
+                  {user?.role?.toLowerCase() === 'admin' && (
+                    <DropdownMenuItem
+                      onClick={() => navigate('/admin')}
+                      className="cursor-pointer hover:bg-cyber-blue/10 text-gray-300 hover:text-white"
+                    >
+                      <UserRound className="mr-2 h-4 w-4" />
+                      관리자 페이지
+                    </DropdownMenuItem>
+                  )}
                   <DropdownMenuSeparator className="bg-gray-700" />
                   <DropdownMenuItem 
                     onClick={handleLogout}

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -5,9 +5,10 @@ import { getCookie } from "@/lib/utils";
 
 interface ProtectedRouteProps {
   children?: React.ReactNode;
+  adminOnly?: boolean; // 관리자 전용 라우트 여부
 }
 
-const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, adminOnly }) => {
   const { user, isLoading } = useUser();
   const token = getCookie("access_token");
 
@@ -18,6 +19,12 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   if (!token || !user) {
     // User is not authenticated, redirect to the login page
     return <Navigate to="/login" replace />;
+  }
+
+  // 관리자 전용 라우트인데 관리자가 아닌 경우
+  if (adminOnly && user.role?.toLowerCase() !== 'admin') {
+    // 관리자가 아니면 홈으로 리디렉션
+    return <Navigate to="/home" replace />;
   }
 
   return children ? <>{children}</> : <Outlet />;

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -7,6 +7,7 @@ interface User {
   username: string;
   user_id: number;
   nickname: string;
+  role: string;
   use_lang?: string;
   name?: string;
   totalScore?: number;

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import Header from '@/components/Header';
+import AdminSidebar from './components/AdminSidebar';
+import ReportList from './components/ReportList';
+import ProblemList from './components/ProblemList';
+import AchievementList from './components/AchievementList';
+import UserList from './components/UserList';
+
+import { useAchievements } from './hooks/useAchievements';
+import { useReports } from './hooks/useReports';
+import { useProblems } from './hooks/useProblems';
+import { useUsers } from './hooks/useUsers';
+
+import CyberCard from '@/components/CyberCard';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Shield } from 'lucide-react';
+
+const AdminPage = () => {
+  const [activeTab, setActiveTab] = useState('reports');
+
+  // hooks에서 데이터 가져오기
+  const { reports, loading: reportsLoading, error: reportsError } = useReports();
+  const { problems, loading: problemsLoading, error: problemsError } = useProblems();
+  const { achievements, loading: achievementsLoading, error: achievementsError } = useAchievements();
+  const { users, loading: usersLoading, error: usersError, fetchUsers } = useUsers();
+
+  // 탭 헤더 정보
+  const tabTitles = {
+    reports: '사용자 신고 내역',
+    problems: '문제 관리',
+    achievements: '업적 관리',
+    users: '사용자 관리',
+  };
+
+  return (
+    <div className="min-h-screen cyber-grid">
+      <Header />
+      <main className="container mx-auto px-4 py-8">
+        <div className="max-w-7xl mx-auto">
+          {/* 페이지 헤더 */}
+          <div className="flex items-center justify-between mb-8">
+            <div className="flex items-center space-x-3">
+              <Shield className="h-8 w-8 text-red-400" />
+              <h1 className="text-3xl font-bold text-white">관리자 대시보드</h1>
+            </div>
+            {/* 검색/필터 등은 별도 분리하여 필요 시 각 리스트 컴포넌트에서 구현 권장 */}
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
+            {/* 사이드바 탭 */}
+            <div className="lg:col-span-1">
+              <AdminSidebar activeTab={activeTab} setActiveTab={setActiveTab} />
+            </div>
+            {/* 메인 콘텐츠 */}
+            <div className="lg:col-span-3">
+              <CyberCard>
+                <div className="h-[600px] overflow-hidden">
+                  <ScrollArea className="h-full">
+                    <div className="pr-4">
+                      {activeTab === 'reports' && (
+                        reportsLoading ? (
+                          <div className="text-gray-400 text-center py-8">로딩 중...</div>
+                        ) : reportsError ? (
+                          <div className="text-red-400 text-center py-8">{reportsError.message}</div>
+                        ) : (
+                          <ReportList userReports={reports} />
+                        )
+                      )}
+
+                      {activeTab === 'problems' && (
+                        problemsLoading ? (
+                          <div className="text-gray-400 text-center py-8">로딩 중...</div>
+                        ) : problemsError ? (
+                          <div className="text-red-400 text-center py-8">{problemsError.message}</div>
+                        ) : (
+                          <ProblemList problems={problems} />
+                        )
+                      )}
+
+                      {activeTab === 'achievements' && (
+                        achievementsLoading ? (
+                          <div className="text-gray-400 text-center py-8">로딩 중...</div>
+                        ) : achievementsError ? (
+                          <div className="text-red-400 text-center py-8">{achievementsError.message}</div>
+                        ) : (
+                          <AchievementList achievements={achievements} />
+                        )
+                      )}
+
+                      {activeTab === 'users' && (
+                        usersLoading ? (
+                          <div className="text-gray-400 text-center py-8">로딩 중...</div>
+                        ) : usersError ? (
+                          <div className="text-red-400 text-center py-8">{usersError.message}</div>
+                        ) : (
+                          <UserList users={users} refreshUsers={fetchUsers} />
+                        )
+                      )}
+                    </div>
+                  </ScrollArea>
+                </div>
+              </CyberCard>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default AdminPage;

--- a/src/pages/admin/api/adminApi.ts
+++ b/src/pages/admin/api/adminApi.ts
@@ -1,0 +1,42 @@
+export async function fetchAchievements() {
+  const response = await fetch('/api/admin/achievements');
+  if (!response.ok) throw new Error('업적 데이터를 불러오지 못했습니다');
+  return response.json();
+}
+
+export async function fetchReports() {
+  const response = await fetch('/api/admin/reports');
+  if (!response.ok) throw new Error('신고 데이터를 불러오지 못했습니다');
+  return response.json();
+}
+
+export async function fetchProblems() {
+  const response = await fetch('/api/admin/problems');
+  if (!response.ok) throw new Error('문제 데이터를 불러오지 못했습니다');
+  return response.json();
+}
+
+export async function fetchUsers() {
+  const response = await fetch('/api/admin/users');
+  if (!response.ok) throw new Error('유저 데이터를 불러오지 못했습니다');
+  return response.json();
+}
+
+export async function banUser(userId: number) {
+  const response = await fetch(`/api/admin/users/${userId}/ban`, {
+    method: 'POST',
+  });
+  if (!response.ok) throw new Error('유저 정지에 실패했습니다');
+  return response.json();
+}
+
+export async function unbanUser(user_id: number) {
+  const response = await fetch(`/api/admin/users/${user_id}/unban`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!response.ok) throw new Error('정지 해제에 실패했습니다');
+  return response.json();
+}

--- a/src/pages/admin/components/AchievementList.tsx
+++ b/src/pages/admin/components/AchievementList.tsx
@@ -1,0 +1,66 @@
+import CyberButton from '@/components/CyberButton';
+import { Plus, Edit, Trash2 } from 'lucide-react';
+
+interface Achievement {
+  id: number;
+  title: string;
+  description: string;
+  rarity: string;
+  unlocked: number;
+}
+
+interface Props {
+  achievements: Achievement[];
+}
+
+const getRarityColor = (rarity: string) => {
+  switch (rarity) {
+    case 'common': return 'text-gray-300';
+    case 'rare': return 'text-blue-400';
+    case 'epic': return 'text-purple-400';
+    case 'legendary': return 'text-yellow-400';
+    default: return 'text-gray-300';
+  }
+};
+
+const AchievementList = ({ achievements }: Props) => (
+  <div className="space-y-4">
+    <div className="flex items-center justify-between">
+      <h2 className="text-xl font-bold text-white">업적 관리</h2>
+      <CyberButton size="sm">
+        <Plus className="h-4 w-4" />
+        새 업적 추가
+      </CyberButton>
+    </div>
+    <div className="space-y-3">
+      {achievements.map(achievement => (
+        <div key={achievement.id} className="p-4 bg-black/20 rounded-lg border border-gray-700/50">
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="text-white font-medium">{achievement.title}</h3>
+            <span className={`text-sm font-medium ${getRarityColor(achievement.rarity)}`}>
+              {achievement.rarity}
+            </span>
+          </div>
+          <p className="text-gray-300 text-sm mb-3">{achievement.description}</p>
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-gray-400">
+              달성한 사용자: {achievement.unlocked.toLocaleString()}명
+            </span>
+            <div className="flex space-x-2">
+              <CyberButton size="sm" variant="secondary">
+                <Edit className="h-4 w-4" />
+                수정
+              </CyberButton>
+              <CyberButton size="sm" className="bg-red-500/20 text-red-400 hover:bg-red-500/30">
+                <Trash2 className="h-4 w-4" />
+                삭제
+              </CyberButton>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export default AchievementList;

--- a/src/pages/admin/components/AdminHeader.tsx
+++ b/src/pages/admin/components/AdminHeader.tsx
@@ -1,0 +1,27 @@
+import { Search, Filter, Shield } from 'lucide-react';
+import CyberButton from '@/components/CyberButton';
+
+const AdminHeader = () => (
+<div className="flex items-center justify-between mb-8">
+    <div className="flex items-center space-x-3">
+      <Shield className="h-8 w-8 text-red-400" />
+      <h1 className="text-3xl font-bold text-white">관리자 대시보드</h1>
+    </div>
+    <div className="flex items-center space-x-4">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+        <input
+          type="text"
+          placeholder="검색..."
+          className="pl-10 pr-4 py-2 bg-black/20 border border-cyber-blue/20 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-cyber-blue"
+        />
+      </div>
+      <CyberButton size="sm">
+        <Filter className="h-4 w-4" />
+        필터
+      </CyberButton>
+    </div>
+  </div>
+);
+
+export default AdminHeader;

--- a/src/pages/admin/components/AdminSidebar.tsx
+++ b/src/pages/admin/components/AdminSidebar.tsx
@@ -1,0 +1,37 @@
+import { AlertTriangle, FileText, Trophy, Users } from 'lucide-react';
+
+const tabs = [
+  { id: 'reports', label: '신고 관리', icon: AlertTriangle },
+  { id: 'problems', label: '문제 관리', icon: FileText },
+  { id: 'achievements', label: '업적 관리', icon: Trophy },
+  { id: 'users', label: '사용자 관리', icon: Users }
+];
+
+interface Props {
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
+}
+
+const AdminSidebar = ({ activeTab, setActiveTab }: Props) => (
+  <nav className="space-y-2">
+    {tabs.map(tab => {
+      const Icon = tab.icon;
+      return (
+        <button
+          key={tab.id}
+          onClick={() => setActiveTab(tab.id)}
+          className={`w-full flex items-center space-x-3 px-4 py-3 rounded-lg transition-all duration-200 ${
+            activeTab === tab.id
+              ? 'bg-cyber-blue/20 text-cyber-blue border border-cyber-blue/30'
+              : 'text-gray-300 hover:bg-gray-800/50 hover:text-white'
+          }`}
+        >
+          <Icon className="h-5 w-5" />
+          <span className="font-medium">{tab.label}</span>
+        </button>
+      );
+    })}
+  </nav>
+);
+
+export default AdminSidebar;

--- a/src/pages/admin/components/ProblemList.tsx
+++ b/src/pages/admin/components/ProblemList.tsx
@@ -1,0 +1,73 @@
+import CyberButton from '@/components/CyberButton';
+import { Plus, Edit, Trash2 } from 'lucide-react';
+
+interface Problem {
+  id: number;
+  title: string;
+  difficulty: string;
+  category: string[];
+  status: string;
+  submissions: number;
+  successRate: string;
+}
+
+interface Props {
+  problems: Problem[];
+}
+
+const getStatusColor = (status: string) => {
+  switch (status) {
+    case 'active': return 'text-green-400 bg-green-400/20';
+    default: return 'text-gray-400 bg-gray-400/20';
+  }
+};
+
+const ProblemList = ({ problems }: Props) => (
+  <div className="space-y-4">
+    <div className="flex items-center justify-between">
+      <h2 className="text-xl font-bold text-white">문제 관리</h2>
+      <CyberButton size="sm">
+        <Plus className="h-4 w-4" />
+        새 문제 추가
+      </CyberButton>
+    </div>
+    <div className="space-y-3">
+      {problems.map(problem => (
+        <div key={problem.id} className="p-4 bg-black/20 rounded-lg border border-gray-700/50">
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="text-white font-medium">{problem.title}</h3>
+            <span className={`px-2 py-1 rounded text-xs ${getStatusColor(problem.status)}`}>
+              활성
+            </span>
+          </div>
+          <div className="flex items-center space-x-4 text-sm text-gray-300 mb-3">
+            <span>난이도: <span className="text-cyber-blue">{problem.difficulty}</span></span>
+            <span>제출: {problem.submissions}회</span>
+            <span>성공률: {problem.successRate}</span>
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="flex flex-wrap gap-1">
+              {problem.category.map((cat, i) => (
+                <span key={i} className="px-2 py-1 bg-cyber-purple/20 text-cyber-purple text-xs rounded">
+                  {cat}
+                </span>
+              ))}
+            </div>
+            <div className="flex space-x-2">
+              <CyberButton size="sm" variant="secondary">
+                <Edit className="h-4 w-4" />
+                수정
+              </CyberButton>
+              <CyberButton size="sm" className="bg-red-500/20 text-red-400 hover:bg-red-500/30">
+                <Trash2 className="h-4 w-4" />
+                삭제
+              </CyberButton>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export default ProblemList;

--- a/src/pages/admin/components/ReportList.tsx
+++ b/src/pages/admin/components/ReportList.tsx
@@ -1,0 +1,67 @@
+import CyberButton from '@/components/CyberButton';
+import { Eye, Ban, UnlockKeyhole } from 'lucide-react';
+
+interface Report {
+  id: number;
+  reportedUser: string;
+  reportedBy: string;
+  reason: string;
+  date: string;
+  status: string;
+}
+
+interface Props {
+  userReports: Report[];
+}
+
+const getStatusColor = (status: string) => {
+  switch (status) {
+    case 'pending': return 'text-yellow-400 bg-yellow-400/20';
+    case 'resolved': return 'text-green-400 bg-green-400/20';
+    default: return 'text-gray-400 bg-gray-400/20';
+  }
+};
+
+const ReportList = ({ userReports }: Props) => (
+  <div className="space-y-4">
+    <div className="flex items-center justify-between">
+      <h2 className="text-xl font-bold text-white">사용자 신고 내역</h2>
+      <span className="text-sm text-gray-400">총 {userReports.length}건</span>
+    </div>
+    <div className="space-y-3">
+      {userReports.map(report => (
+        <div key={report.id} className="p-4 bg-black/20 rounded-lg border border-gray-700/50">
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center space-x-3">
+              <span className="text-white font-medium">{report.reportedUser}</span>
+              <span className={`px-2 py-1 rounded text-xs ${getStatusColor(report.status)}`}>
+                {report.status === 'pending' ? '대기중' : '처리완료'}
+              </span>
+            </div>
+            <span className="text-sm text-gray-400">{report.date}</span>
+          </div>
+          <div className="text-sm text-gray-300 mb-3">
+            <span className="text-gray-400">신고자:</span> {report.reportedBy} | 
+            <span className="text-gray-400"> 사유:</span> {report.reason}
+          </div>
+          <div className="flex space-x-2">
+            <CyberButton size="sm" variant="secondary">
+              <Eye className="h-4 w-4" />
+              상세보기
+            </CyberButton>
+            <CyberButton size="sm" className="bg-red-500/20 text-red-400 hover:bg-red-500/30">
+              <Ban className="h-4 w-4" />
+              제재
+            </CyberButton>
+            <CyberButton size="sm" variant="secondary">
+              <UnlockKeyhole className="h-4 w-4" />
+              무시
+            </CyberButton>
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export default ReportList;

--- a/src/pages/admin/components/UserList.tsx
+++ b/src/pages/admin/components/UserList.tsx
@@ -1,0 +1,97 @@
+import { User } from '../hooks/useUsers';
+import CyberButton from '@/components/CyberButton';
+import { Users } from 'lucide-react';
+import { unbanUser, banUser } from '../api/adminApi';
+
+interface Props {
+  users: User[];
+  refreshUsers: () => void;
+}
+
+const UserList = ({ users, refreshUsers }: Props) => {
+  // 정지 해제 핸들러
+  const handleUnban = async (user_id: number) => {
+    try {
+      await unbanUser(user_id);
+      refreshUsers();
+    } catch (err) {
+      alert('정지 해제에 실패했습니다');
+    }
+  };
+
+  // 정지 핸들러 (원하시면 banUser도 만드세요)
+  const handleBan = async (user_id: number) => {
+    try {
+      await banUser(user_id);
+      refreshUsers();
+    } catch (err) {
+      alert('정지 처리에 실패했습니다');
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-bold text-white">사용자 관리</h2>
+        <span className="text-sm text-gray-400">총 {users.length}명</span>
+      </div>
+      <div className="overflow-x-auto">
+        {users.length === 0 ? (
+          <div className="text-center py-12">
+            <Users className="h-16 w-16 text-gray-600 mx-auto mb-4" />
+            <p className="text-gray-400">등록된 사용자가 없습니다.</p>
+          </div>
+        ) : (
+          <table className="w-full text-left">
+            <thead>
+              <tr>
+                <th className="p-2">닉네임</th>
+                <th className="p-2">이메일</th>
+                <th className="p-2">상태</th>
+                <th className="p-2">신고횟수</th>
+                <th className="p-2">관리</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((user) => (
+                <tr key={user.user_id} className={user.is_banned ? "bg-red-900/30" : ""}>
+                  <td className="p-2">{user.nickname}</td>
+                  <td className="p-2">{user.email}</td>
+                  <td className="p-2">
+                    {user.is_banned ? (
+                      <span className="px-2 py-1 bg-red-500/30 text-red-400 rounded">정지됨</span>
+                    ) : (
+                      <span className="px-2 py-1 bg-green-500/30 text-green-400 rounded">정상</span>
+                    )}
+                  </td>
+                  <td className="p-2">
+                    <span className="px-2 py-1 bg-yellow-500/30 text-yellow-400 rounded">
+                      {user.report_count ?? 0}회
+                    </span>
+                  </td>
+                  <td className="p-2 space-x-1">
+                    {user.is_banned ? (
+                      <CyberButton size="sm" variant="secondary" onClick={() => handleUnban(user.user_id)}>
+                        해제
+                      </CyberButton>
+                    ) : (
+                      <CyberButton
+                        size="sm"
+                        className="bg-red-500/20 text-red-400 hover:bg-red-500/30"
+                        onClick={() => handleBan(user.user_id)}
+                      >
+                        정지
+                      </CyberButton>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default UserList;

--- a/src/pages/admin/hooks/useAchievements.ts
+++ b/src/pages/admin/hooks/useAchievements.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { fetchAchievements } from '../api/adminApi';
+
+export interface Achievement {
+  id: number;
+  title: string;
+  description: string;
+  rarity: string;
+  unlocked: number;
+}
+
+export function useAchievements() {
+  const [achievements, setAchievements] = useState<Achievement[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<null | Error>(null);
+
+  useEffect(() => {
+    fetchAchievements()
+      .then(setAchievements)
+      .catch(setError)
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { achievements, loading, error };
+}

--- a/src/pages/admin/hooks/useProblems.ts
+++ b/src/pages/admin/hooks/useProblems.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { fetchProblems } from '../api/adminApi';
+
+export interface Problem {
+  id: number;
+  title: string;
+  difficulty: string;
+  category: string[];
+  status: string;
+  submissions: number;
+  successRate: string;
+}
+
+export function useProblems() {
+  const [problems, setProblems] = useState<Problem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<null | Error>(null);
+
+  useEffect(() => {
+    fetchProblems()
+      .then(setProblems)
+      .catch(setError)
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { problems, loading, error };
+}

--- a/src/pages/admin/hooks/useReports.ts
+++ b/src/pages/admin/hooks/useReports.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { fetchReports } from '../api/adminApi';
+
+export interface Report {
+  id: number;
+  reportedUser: string;
+  reportedBy: string;
+  reason: string;
+  date: string;
+  status: string;
+}
+
+export function useReports() {
+  const [reports, setReports] = useState<Report[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<null | Error>(null);
+
+  useEffect(() => {
+    fetchReports()
+      .then(setReports)
+      .catch(setError)
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { reports, loading, error };
+}

--- a/src/pages/admin/hooks/useUsers.ts
+++ b/src/pages/admin/hooks/useUsers.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState, useCallback } from 'react';
+import { fetchUsers as fetchUsersApi } from '../api/adminApi';
+
+export interface User {
+  user_id: number;
+  nickname: string;
+  email: string;
+  tier: string;
+  is_banned: boolean;
+  report_count: number;
+}
+
+export function useUsers() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<null | Error>(null);
+
+  const fetchUsers = useCallback(() => {
+    setLoading(true);
+    fetchUsersApi()
+      .then(setUsers)
+      .catch(setError)
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  return { users, loading, error, fetchUsers }; 
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,13 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000/api/v1',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      }
+    }
   },
   plugins: [react(), mode === "development" && componentTagger()].filter(
     Boolean,


### PR DESCRIPTION
어드민 페이지(AdminPage)에 네비게이션 및 탭 구조 도입

어드민 사이드바(AdminSidebar), 헤더(AdminHeader), 업적 목록(AchievementList), 문제 목록(ProblemList), 신고 목록(ReportList), 유저 목록(UserList) 컴포넌트 생성

어드민 데이터 조회용 커스텀 훅(useAchievements, useReports, useProblems, useUsers) 구현

ProtectedRoute에서 어드민 권한 기반 라우트 보호 로직 추가

어드민 엔드포인트용 API 프록시 설정(vite.config.ts 업데이트)

유저 컨텍스트(UserContext)와 헤더(Header)에 어드민 관련 기능 추가