### PR TITLE
:recycle: [REFACTOR] 완전한 절대 경로(https://...)가 들어왔는데도 VITE_API_URL을 앞에 …

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -27,5 +27,11 @@ const S3_BASE_URL = import.meta.env.VITE_S3_BASE_URL;
 export const getAbsoluteUrl = (path: string) => {
   if (!path) return "";
   if (path.startsWith("http")) return path;
-  return `${S3_BASE_URL}/${path}`;
+
+  try {
+    const url = new URL(path, S3_BASE_URL);
+    return url.toString();
+  } catch {
+    return "";
+  }
 };


### PR DESCRIPTION
…붙여버려서 생긴 문제 해결

 - utils.ts : path에 http로 시작하면 절대 경로 그대로 사용

그 외는 S3_BASE_URL과 붙이되 슬래시 중복 제거해서 안전하게 조립