### PR TITLE
🐛 [FIX] Github OAuth2 로그인 과정 중 /api쪽 요청을 프론트엔드에 전송

### DIFF
--- a/src/pages/login/components/OAuthCallback.tsx
+++ b/src/pages/login/components/OAuthCallback.tsx
@@ -3,6 +3,9 @@ import {useLocation, useNavigate} from "react-router-dom";
 import {useUser} from "../../../context/UserContext";
 import {authFetch} from "../../../utils/api";
 import { getAbsoluteUrl } from "@/lib/utils";
+// Define your API base URL here
+const apiUrl = import.meta.env.VITE_API_URL;
+
 
 const OAuthCallback = () => {
     const location = useLocation();
@@ -15,7 +18,8 @@ const OAuthCallback = () => {
             const isNewUser = params.get("is_new_user") === "true";
 
             try {
-                const userResponse = await authFetch(`/api/v1/user/me`);
+                // const userResponse = await authFetch(`/api/v1/user/me`);
+                const userResponse = await authFetch(`${apiUrl}/api/v1/user/me`);
 
                 const contentType = userResponse.headers.get("content-type") || "";
                 if (!userResponse.ok || !contentType.includes("application/json")) {


### PR DESCRIPTION
- `/api/v1/user/me`를 프론트엔드에 전송하던 것을 백엔드로 라우팅