### PR TITLE
♻ [REFACTOR] 백으로부터 새 access token을 수신토록

### DIFF
--- a/src/pages/login/components/OAuthCallback.tsx
+++ b/src/pages/login/components/OAuthCallback.tsx
@@ -2,7 +2,7 @@ import React, {useEffect} from "react";
 import {useLocation, useNavigate} from "react-router-dom";
 import {useUser} from "../../../context/UserContext";
 import {authFetch} from "../../../utils/api";
-import { getAbsoluteUrl } from "@/lib/utils";
+import { getAbsoluteUrl,setCookie } from "@/lib/utils";
 // Define your API base URL here
 const apiUrl = import.meta.env.VITE_API_URL;
 
@@ -16,6 +16,7 @@ const OAuthCallback = () => {
         const handleOAuthCallback = async () => {
             const params = new URLSearchParams(location.search);
             const isNewUser = params.get("is_new_user") === "true";
+            const newAccessToken = params.get("new_access_token");
 
             try {
                 // const userResponse = await authFetch(`/api/v1/user/me`);
@@ -27,6 +28,9 @@ const OAuthCallback = () => {
                 }
 
                 const userData = await userResponse.json();
+                
+                // 이거는 `code-ground.com`을 세팅하는 쿠키. `.code-ground-com`은 백엔드에서 세팅했음.
+                setCookie("access_token", newAccessToken, 7); 
 
                 setUser({
                     ...userData,


### PR DESCRIPTION
관련 PR: https://github.com/Kraftonjungle-MyWeapon/Codeground-BE/pull/111
- 백으로부터 전달받은 new_access_token을 받아 웹 도메인 (예: https://code-ground.com/의 `code-ground.com`)에 `setCookie()` 수행
- 백에서 `code-ground.com`, `.code-ground.com` 쿠키를 둘 다 set하도록 구성할 수도 있으나, 기존 로그인 로직과의 일관성을 위해 이렇게 함.