### PR TITLE
🐛 [FIX] 프로필 기본 사진 로드 불가 문제

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -26,7 +26,7 @@ export function eraseCookie(name: string) {
 
 export const getAbsoluteUrl = (path: string) => {
   // console.log("getAbsoluteUrl called with path:", path);
-  if (!path) return "";
+  if (!path || path === "null" || path === "undefined" || path.trim() === "") return "";
   if (/^[a-zA-Z]+:\/\//.test(path)) return path;
 
   try {


### PR DESCRIPTION
- 기본 프로필 사진이 있음에도 불구하고 잘못된 URL 세팅으로 인해 로드되지 않던 버그를 픽스합니다.