### PR TITLE
:recycle: [REFACTOR] 랭킹 페이지, 화면 공유 설정 페이지에서 프로필 이미지 반영되게 수정

### DIFF
--- a/src/pages/ScreenShareSetupPage.tsx
+++ b/src/pages/ScreenShareSetupPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import CyberCard from '@/components/CyberCard';
 import CyberButton from '@/components/CyberButton';
 import { Monitor, User, Clock, AlertTriangle, Check } from 'lucide-react';
+import { getAbsoluteUrl } from "@/lib/utils";
 import { useUser } from '@/context/UserContext';
 import { localStream as sharedLocalStream, remoteStream as sharedRemoteStream, 
     setLocalStream, setRemoteStream, setPeerConnection, peerConnection as sharedPC } from '@/utils/webrtcStore';
@@ -85,6 +86,8 @@ const ScreenShareSetupPage = () => {
   const [isWebRTCConnected, setIsWebRTCConnected] = useState(false);
   const [opponentScreenShareStatus, setOpponentScreenShareStatus] = useState<'waiting' | 'connected' | 'disconnected'>('waiting');
   const [showMyScreenShareRestartButton, setShowMyScreenShareRestartButton] = useState(false);
+  const [opponentNickname, setOpponentNickname] = useState<string | null>(null);
+  const [opponentProfileImageUrl, setOpponentProfileImageUrl] = useState<string | null>(null);
 
   useEffect(() => {
     // 기존 WebRTC 연결 및 스트림 정리
@@ -310,9 +313,13 @@ const ScreenShareSetupPage = () => {
           data.user_id !== user.user_id
         ) {
           setOpponentReady(true);
+          if (data.nickname) setOpponentNickname(data.nickname);
+          if (data.profile_img_url) setOpponentProfileImageUrl(data.profile_img_url);
         } else if (data.type === "all_ready") {
           setOpponentReady(true);
           setMyReady(true);
+          if (data.opponent_nickname) setOpponentNickname(data.opponent_nickname);
+          if (data.opponent_profile_img_url) setOpponentProfileImageUrl(data.opponent_profile_img_url);
         } else if (data.type === 'match_result') {
           console.log('ScreenShareSetupPage: Match result received:', data);
           if (matchType === 'custom') {
@@ -560,8 +567,16 @@ const ScreenShareSetupPage = () => {
             <CyberCard className="p-6">
               <div className="flex items-center justify-between">
                 <div className="flex items-center space-x-4">
-                  <div className="w-12 h-12 bg-gradient-to-r from-cyber-blue to-cyber-purple rounded-full flex items-center justify-center">
-                    <User className="h-6 w-6 text-white" />
+                  <div className="w-12 h-12 bg-gradient-to-r from-cyber-blue to-cyber-purple rounded-full flex items-center justify-center overflow-hidden border-2 border-cyber-blue">
+                    {user?.profileImageUrl ? (
+                      <img
+                        src={getAbsoluteUrl(user.profileImageUrl)}
+                        alt={user.nickname || "내 프로필"}
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <User className="h-6 w-6 text-white" />
+                    )}
                   </div>
                   <div>
                     <div className="text-white font-semibold">나</div>
@@ -617,8 +632,16 @@ const ScreenShareSetupPage = () => {
                       )}
                     </div>
                   </div>
-                  <div className="w-12 h-12 bg-gradient-to-r from-red-500 to-pink-500 rounded-full flex items-center justify-center">
-                    <User className="h-6 w-6 text-white" />
+                  <div className="w-12 h-12 bg-gradient-to-r from-red-500 to-pink-500 rounded-full flex items-center justify-center overflow-hidden border-2 border-cyber-blue">
+                    {opponentProfileImageUrl ? (
+                      <img
+                        src={getAbsoluteUrl(opponentProfileImageUrl)}
+                        alt={opponentNickname || "상대방 프로필"}
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <User className="h-6 w-6 text-white" />
+                    )}
                   </div>
                 </div>
               </div>

--- a/src/pages/ranking/RankingPage.tsx
+++ b/src/pages/ranking/RankingPage.tsx
@@ -76,6 +76,7 @@ const RankingPage = () => {
                 <SelectItem value="python3">Python</SelectItem>
                 <SelectItem value="java">Java</SelectItem>
                 <SelectItem value="cpp">C++</SelectItem>
+                <SelectItem value="c">C</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/src/pages/ranking/components/RankingList.tsx
+++ b/src/pages/ranking/components/RankingList.tsx
@@ -13,6 +13,7 @@ import {
 import { parseTotalScore } from "@/utils/lpSystem";
 import { FC } from "react";
 import type { RankingEntry } from "./TopThreeRanking";
+import { getAbsoluteUrl } from "@/lib/utils";
 
 const getRankIcon = (rank: number) => {
   switch (rank) {
@@ -82,8 +83,16 @@ const RankingList: FC<Props> = ({ players }) => (
                     #{player.rank}
                   </div>
                   <div className="flex items-center space-x-3">
-                    <div className="w-10 h-10 bg-gradient-to-r from-cyber-blue to-cyber-purple rounded-full flex items-center justify-center">
-                      <User className="h-5 w-5" />
+                    <div className="w-10 h-10 bg-gradient-to-r from-cyber-blue to-cyber-purple rounded-full flex items-center justify-center overflow-hidden border-2 border-cyber-blue">
+                      {player.profile_img_url ? (
+                        <img
+                          src={getAbsoluteUrl(player.profile_img_url)}
+                          alt={player.nickname}
+                          className="w-full h-full object-cover"
+                        />
+                      ) : (
+                        <User className="h-5 w-5" />
+                      )}
                     </div>
                     <div>
                       <div className="font-semibold text-white">

--- a/src/pages/ranking/components/TopThreeRanking.tsx
+++ b/src/pages/ranking/components/TopThreeRanking.tsx
@@ -8,12 +8,15 @@ import {
   ArrowUp,
   ArrowDown,
   Minus,
+  User,
 } from "lucide-react";
 import { FC } from "react";
+import { getAbsoluteUrl } from "@/lib/utils";
 
 export interface RankingEntry {
   user_id: number;
   nickname: string;
+  profile_img_url?: string;
   mmr: number;
   rank: number;
   rank_diff: number;
@@ -69,9 +72,20 @@ const TopThreeRanking: FC<Props> = ({ players }) => (
       return (
         <CyberCard
           key={player.rank}
-          className={`text-center ${getRankColor(player.rank)}`}
+          className={`relative text-center ${getRankColor(player.rank)}`}
         >
-          <div className="mb-4">{getRankIcon(player.rank)}</div>
+          <div className="w-24 h-24 bg-gradient-to-r from-cyber-blue to-cyber-purple rounded-full mx-auto mb-4 flex items-center justify-center overflow-hidden border-2 border-cyber-blue">
+            {player.profile_img_url ? (
+              <img
+                src={getAbsoluteUrl(player.profile_img_url)}
+                alt={player.nickname}
+                className="w-full h-full object-cover"
+              />
+            ) : (
+              <User className="h-12 w-12 text-white" />
+            )}
+          </div>
+          <div className="absolute top-4 left-4">{getRankIcon(player.rank)}</div>
           <div className="text-2xl font-bold mb-1">{player.rank}위</div>
           <div className="text-lg font-semibold text-white mb-2">
             {player.nickname}

--- a/src/pages/setup-profile/components/ProfileImageUpload.tsx
+++ b/src/pages/setup-profile/components/ProfileImageUpload.tsx
@@ -1,4 +1,5 @@
 import { Upload, User } from "lucide-react";
+import { useState, useEffect } from "react";
 
 interface ProfileImageUploadProps {
   file: File | null;
@@ -6,6 +7,18 @@ interface ProfileImageUploadProps {
 }
 
 const ProfileImageUpload = ({ file, onChange }: ProfileImageUploadProps) => {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (file) {
+      const url = URL.createObjectURL(file);
+      setPreviewUrl(url);
+      return () => URL.revokeObjectURL(url);
+    } else {
+      setPreviewUrl(null);
+    }
+  }, [file]);
+
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selected = e.target.files?.[0] || null;
     onChange(selected);
@@ -13,8 +26,12 @@ const ProfileImageUpload = ({ file, onChange }: ProfileImageUploadProps) => {
 
   return (
     <div className="space-y-2 text-center">
-      <div className="w-20 h-20 bg-gradient-to-r from-cyber-blue to-cyber-purple rounded-full mx-auto flex items-center justify-center">
-        <User className="h-10 w-10 text-white" />
+      <div className="w-20 h-20 bg-gradient-to-r from-cyber-blue to-cyber-purple rounded-full mx-auto flex items-center justify-center overflow-hidden border-2 border-cyber-blue">
+        {previewUrl ? (
+          <img src={previewUrl} alt="Profile Preview" className="w-full h-full object-cover" />
+        ) : (
+          <User className="h-10 w-10 text-white" />
+        )}
       </div>
       <label
         htmlFor="profileImage"


### PR DESCRIPTION
RankingList.tsx : 랭킹 목록의 각 플레이어 항목에서 프로필 이미지를 표시하는 로직을 추가했습니다. player.profile_img_url이 존재하면 해당 이미지를 getAbsoluteUrl을 통해 절대 경로로 변환하여 사용하고, 없으면 기본 User 아이콘을 표시하도록 변경

TopThreeRanking.tsx : 상위 3명 랭킹 카드의 각 플레이어 항목에서 프로필 이미지를 표시하는 로직을 추가했습니다. player.profile_img_url이 존재하면 해당 이미지를 getAbsoluteUrl을 통해 절대 경로로 변환하여 사용하고, 없으면 기본 User 아이콘을 표시하도록 변경

ScreenShareSetupPage.tsx : "나" (현재 사용자)와 상대방의 프로필 이미지를 표시하는 로직을 추가했습니다. user?.profileImageUrl이 존재하면 해당 이미지를 getAbsoluteUrl을 통해 절대 경로로 변환하여 사용하고, 없으면 기본 User 아이콘을 표시하도록 변경

ProfileImageUpload.tsx : 프로필 이미지 업로드 시 미리보기 기능 추가