### PR TITLE
✨ [FEAT] 스크린 공유 시 화질을 떨어뜨려 송출

### DIFF
--- a/src/hooks/useBattleScreenShare.ts
+++ b/src/hooks/useBattleScreenShare.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { localStream as sharedLocalStream, setLocalStream, peerConnection as sharedPC, setPeerConnection, setRemoteStream } from '@/utils/webrtcStore';
+import { getScaledDisplayMedia } from '@/utils/getScaledDisplayMedia';
 import useWebSocketStore from '@/stores/websocketStore';
 import { useNavigate } from 'react-router-dom';
 
@@ -54,7 +55,7 @@ export const useBattleScreenShare = ({
 
   const startLocalScreenShare = useCallback(async () => {
     try {
-      const stream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: false });
+      const stream = await getScaledDisplayMedia();
       setLocalStream(stream);
       setIsLocalStreamActive(true);
       setShowLocalScreenSharePrompt(false);

--- a/src/hooks/useScreenShareSetup.ts
+++ b/src/hooks/useScreenShareSetup.ts
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import { getScaledDisplayMedia } from "@/utils/getScaledDisplayMedia";
 import { useUser } from "@/context/UserContext";
 import { 
   localStream as sharedLocalStream, 
@@ -77,10 +78,11 @@ export function useScreenShareSetup() {
     console.log("[ScreenShare] Attempting to start screen share.");
     try {
       setMyShareStatus("sharing");
-      const mediaStream = await navigator.mediaDevices.getDisplayMedia({
-        video: true,
-        audio: false,
-      });
+      // const mediaStream = await navigator.mediaDevices.getDisplayMedia({
+      //   video: true,
+      //   audio: false,
+      // });
+      const mediaStream = await getScaledDisplayMedia();
       console.log("[ScreenShare] getDisplayMedia success.", mediaStream);
       const videoTrack = mediaStream.getVideoTracks()[0];
       const settings = videoTrack.getSettings() as any;
@@ -406,10 +408,7 @@ export function useScreenShareSetup() {
     console.log("[ScreenShare] Restarting screen share process.");
     try {
       setMyShareStatus("sharing");
-      const mediaStream = await navigator.mediaDevices.getDisplayMedia({
-        video: true,
-        audio: false,
-      });
+      const mediaStream = await getScaledDisplayMedia();
       const videoTrack = mediaStream.getVideoTracks()[0];
       const settings = videoTrack.getSettings() as any;
       if (settings.displaySurface === "monitor") {

--- a/src/pages/ScreenShareSetupPage.tsx
+++ b/src/pages/ScreenShareSetupPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { getScaledDisplayMedia } from '@/utils/getScaledDisplayMedia';
 import CyberCard from '@/components/CyberCard';
 import CyberButton from '@/components/CyberButton';
 import { Monitor, User, Clock, AlertTriangle, Check } from 'lucide-react';
@@ -147,11 +148,7 @@ const ScreenShareSetupPage = () => {
   const startScreenShare = async () => {
     try {
       setMyShareStatus("sharing");
-      const mediaStream = await navigator.mediaDevices.getDisplayMedia({
-        video: true,
-        audio: false,
-      });
-
+      const mediaStream = await getScaledDisplayMedia();
       const videoTrack = mediaStream.getVideoTracks()[0];
       const settings = videoTrack.getSettings() as any;
 
@@ -503,11 +500,7 @@ const ScreenShareSetupPage = () => {
   const handleRestartScreenShare = async () => {
     try {
       setMyShareStatus('sharing');
-      const mediaStream = await navigator.mediaDevices.getDisplayMedia({
-        video: true,
-        audio: false,
-      });
-
+      const mediaStream = await getScaledDisplayMedia();
       const videoTrack = mediaStream.getVideoTracks()[0];
       const settings = videoTrack.getSettings() as any;
 

--- a/src/utils/getScaledDisplayMedia.ts
+++ b/src/utils/getScaledDisplayMedia.ts
@@ -1,0 +1,8 @@
+export async function getScaledDisplayMedia(): Promise<MediaStream> {
+  const width = Math.floor(window.screen.width * 0.25);
+  const height = Math.floor(window.screen.height * 0.25);
+  return navigator.mediaDevices.getDisplayMedia({
+    video: { width, height },
+    audio: false,
+  });
+}


### PR DESCRIPTION
- 스크린 공유할 때 클라이언트의 부담을 줄이기 위하여 해상도를 25%로 줄여 송출합니다.
- 예시: 1920 * 1080 ==> 480 * 270

 **현재 로컬에서 테스트 불가하여 테스트 서버에서 해보고 오작동 시 롤백 요망** 
